### PR TITLE
feat: add distinctive icons to sensor entities for better UI clarity

### DIFF
--- a/custom_components/retention_cleaner/sensor.py
+++ b/custom_components/retention_cleaner/sensor.py
@@ -9,11 +9,11 @@ from .coordinator import RetentionCleanerCoordinator
 
 
 SENSOR_DEFS = [
-    ("total_files", "Total files", "files"),
-    ("older_than_retention", "Older than retention", "files"),
-    ("deleted_last_run", "Deleted last cleanup", "files"),
-    ("last_scan", "Last scan", None),
-    ("last_cleanup", "Last cleanup", None),
+    ("total_files", "Total files", "files", "mdi:file-multiple"),
+    ("older_than_retention", "Older than retention", "files", "mdi:clock-alert"),
+    ("deleted_last_run", "Deleted last cleanup", "files", "mdi:delete-empty"),
+    ("last_scan", "Last scan", None, "mdi:folder-search"),
+    ("last_cleanup", "Last cleanup", None, "mdi:broom"),
 ]
 
 
@@ -21,8 +21,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
     coordinator: RetentionCleanerCoordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
         [
-            RetentionCleanerSensor(coordinator, entry, key, name, unit)
-            for key, name, unit in SENSOR_DEFS
+            RetentionCleanerSensor(coordinator, entry, key, name, unit, icon)
+            for key, name, unit, icon in SENSOR_DEFS
         ]
     )
 
@@ -35,6 +35,7 @@ class RetentionCleanerSensor(CoordinatorEntity[RetentionCleanerCoordinator], Sen
         key: str,
         name: str,
         unit: str | None,
+        icon: str,
     ):
         super().__init__(coordinator)
         self._key = key
@@ -45,6 +46,7 @@ class RetentionCleanerSensor(CoordinatorEntity[RetentionCleanerCoordinator], Sen
         title = entry.title or coordinator.base_path
         self._attr_name = name
         self._attr_native_unit_of_measurement = unit
+        self._attr_icon = icon
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry.entry_id)},


### PR DESCRIPTION
## Summary
  - Added distinctive Material Design Icons to all sensor entities
  - Improves visual distinction between different sensor types in the Home Assistant dashboard
  - Makes the integration more intuitive and professional-looking

  ## Changes
  - `total_files`: `mdi:file-multiple` - Shows multiple files icon
  - `older_than_retention`: `mdi:clock-alert` - Warning clock for old files
  - `deleted_last_run`: `mdi:delete-empty` - Trash/delete icon
  - `last_scan`: `mdi:folder-search` - Folder with magnifying glass
  - `last_cleanup`: `mdi:broom` - Broom for cleanup operations