### PR TITLE
fix: add UTC timezone to TIMESTAMP sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [1.0.8]
 
 ### Fixed
-- Use datetime objects for TIMESTAMP device class sensors instead of strings
+- Use datetime objects with UTC timezone for TIMESTAMP device class sensors
 
 ## [1.0.7]
 

--- a/custom_components/retention_cleaner/coordinator.py
+++ b/custom_components/retention_cleaner/coordinator.py
@@ -5,7 +5,7 @@ import errno
 import logging
 import time
 from dataclasses import dataclass
-from datetime import datetime, timedelta, time as dt_time
+from datetime import datetime, timedelta, time as dt_time, timezone
 from pathlib import Path
 from typing import Any
 
@@ -67,16 +67,16 @@ class CleanupResult:
 
 
 def _now() -> datetime:
-    """Generate current timestamp.
+    """Generate current timestamp with UTC timezone.
 
     Returns:
-        datetime: Current datetime object.
+        datetime: Current datetime object with UTC timezone.
 
     Example:
         >>> _now()
-        datetime.datetime(2024, 1, 2, 15, 30, 45)
+        datetime.datetime(2024, 1, 2, 15, 30, 45, tzinfo=timezone.utc)
     """
-    return datetime.now()
+    return datetime.now(timezone.utc)
 
 
 async def _retry_async_operation(func, *args, max_retries: int = 3, delay: float = 0.5):


### PR DESCRIPTION
Add UTC timezone information to datetime objects for TIMESTAMP device class sensors.

  ## Problem

  Home Assistant requires timezone-aware datetime objects for TIMESTAMP sensors. Using `datetime.now()` returns naive datetime without timezone info, causing ValueError:
  ValueError: Invalid datetime: sensor provides state '2026-01-07 22:09:59.959624', which is missing timezone information

  ## Solution

  Use `datetime.now(timezone.utc)` to return timezone-aware datetime objects with UTC timezone.

  ## Changes

  - Add `timezone` import from datetime module
  - Change `_now()` to return `datetime.now(timezone.utc)`
  - Update CHANGELOG for v1.0.8