### PR TITLE
feat: add folder size monitoring sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Respects `dry_run` mode for safe testing
   - Gracefully handles race conditions and permission errors
   - Default: false (opt-in for safety)
+- Folder size monitoring sensors for storage tracking
+  - `total_folder_size_bytes` sensor: Shows total size of all files matching pattern/extension filters
+  - `older_than_retention_size_bytes` sensor: Shows size of files eligible for deletion
+  - Both sensors use DATA_SIZE device class for automatic unit conversion (KB/MB/GB)
+  - Zero performance impact: Size calculated during existing file scan
+  - Updates on every scan operation
+  - Useful for comparing storage usage across multiple cleanup rules
 
 ### Changed
 - Improved code quality with refactored helpers and reduced duplication

--- a/README.md
+++ b/README.md
@@ -146,6 +146,60 @@ With this configuration:
 
 **Valid Range:** 0-1,000,000 (0 = disabled)
 
+### Folder Size Monitoring Sensors
+
+Track storage usage across your retention cleanup rules with two specialized sensors that update during every scan:
+
+**Total Folder Size Bytes** - Shows the total size in bytes of ALL files that match your configured pattern and extension filters. This gives you real-time visibility into how much storage is being used by the files under management.
+
+**Older Than Retention Size Bytes** - Shows the size in bytes of files that would be deleted in the next cleanup. This helps you predict how much disk space will be freed before running the cleanup.
+
+```yaml
+Base Path: /media/frigate/recordings
+Pattern: **/*.mp4
+Retention Days: 7
+```
+
+With this configuration:
+- `total_folder_size_bytes` shows total size of all MP4 files in the folder
+- `older_than_retention_size_bytes` shows size of MP4 files older than 7 days
+- Both sensors automatically display as KB/MB/GB in Home Assistant UI
+- Values update on every scan (manual or scheduled)
+
+**Key Benefits:**
+- **Zero performance impact**: Size is collected during existing file scan operations
+- **Pattern-aware**: Only counts files matching your configured pattern and extension filters
+- **Dashboard integration**: Use in Lovelace cards, graphs, and automations
+- **Predictive cleanup**: See how much space will be freed before running cleanup
+- **Multi-instance comparison**: Compare storage usage across different cameras or folders
+
+**Use Cases:**
+- Monitor total storage used by camera recordings across multiple devices
+- Set up alerts when folder size exceeds a threshold
+- Compare retention policies between different camera feeds
+- Create graphs showing storage trends over time
+- Predict disk space recovery before running cleanup
+- Verify cleanup effectiveness by tracking before/after sizes
+
+**Complements Existing Sensors:**
+- Works alongside `deleted_bytes_last_run` which tracks actual cleanup results
+- Updates in real-time during scans, not just after cleanup operations
+- Provides forward-looking metrics (what will be deleted) vs historical (what was deleted)
+
+**Example Automation:**
+```yaml
+automation:
+  - alias: "Alert when camera storage exceeds 50GB"
+    trigger:
+      - platform: numeric_state
+        entity_id: sensor.front_camera_total_folder_size_bytes
+        above: 53687091200  # 50 GB in bytes
+    action:
+      - service: notify.mobile_app
+        data:
+          message: "Front camera storage exceeds 50GB"
+```
+
 ### Remove Empty Subdirectories After Cleanup
 
 Automatically remove empty directory structures after cleaning up old files. This is particularly useful for camera systems that create date-based or event-based folder hierarchies.
@@ -220,6 +274,8 @@ Each cleanup rule provides these entities:
 | **Older than retention** | Files eligible for deletion | files |
 | **Deleted last cleanup** | Files deleted in last run | files |
 | **Deleted bytes last cleanup** | Size of deleted files | bytes |
+| **Total folder size bytes** | Total size of all matched files | bytes |
+| **Older than retention size bytes** | Size of files eligible for deletion | bytes |
 | **Last scan** | Timestamp of last scan | - |
 | **Last cleanup** | Timestamp of last cleanup | - |
 | **Last scan duration** | Performance metric | ms |
@@ -320,6 +376,40 @@ This setup:
 - Removes empty directories after file deletion (e.g., empty `/2024/01/15/camera/` folder)
 - Cleans up recursively until non-empty directory or base_path is reached
 - Preserves directories containing hidden files like `.gitkeep`
+
+### Multi-Camera Storage Monitoring
+
+Monitor storage usage across multiple camera feeds with size sensors:
+
+```yaml
+# Front Door Camera
+Base Path: /media/frigate/recordings/front_door
+Pattern: **/*.mp4
+Retention Days: 14
+
+# Backyard Camera
+Base Path: /media/frigate/recordings/backyard
+Pattern: **/*.mp4
+Retention Days: 7
+
+# Garage Camera
+Base Path: /media/frigate/recordings/garage
+Pattern: **/*.mp4
+Retention Days: 30
+```
+
+This setup provides:
+- **Individual storage tracking**: Each camera gets `total_folder_size_bytes` sensor
+- **Cleanup prediction**: Each camera shows `older_than_retention_size_bytes`
+- **Comparative analysis**: Compare which camera uses most storage
+- **Dashboard cards**: Create graphs showing storage trends per camera
+- **Proactive alerts**: Set up notifications before disk space runs low
+
+**Dashboard Example:**
+The `total_folder_size_bytes` and `older_than_retention_size_bytes` sensors automatically display in GB/MB/KB format in the Home Assistant UI. Create a card showing:
+- Total storage per camera
+- How much will be freed in next cleanup
+- Storage trend graphs over time
 
 ---
 

--- a/custom_components/retention_cleaner/coordinator.py
+++ b/custom_components/retention_cleaner/coordinator.py
@@ -51,11 +51,15 @@ class ScanResult:
         total_files: Total number of files matching the pattern.
         older_than_retention: Number of files older than retention period.
         path_available: Whether the base path exists and is accessible.
+        total_size_bytes: Total size in bytes of all matched files.
+        older_than_retention_size_bytes: Total size in bytes of files older than retention.
     """
 
     total_files: int
     older_than_retention: int
     path_available: bool
+    total_size_bytes: int = 0
+    older_than_retention_size_bytes: int = 0
 
 
 @dataclass
@@ -265,12 +269,20 @@ def _scan_folder(
 
     if not base.exists() or not base.is_dir():
         _LOGGER.warning("Path not accessible or not a directory: %s", base_path)
-        return ScanResult(total_files=0, older_than_retention=0, path_available=False)
+        return ScanResult(
+            total_files=0,
+            older_than_retention=0,
+            path_available=False,
+            total_size_bytes=0,
+            older_than_retention_size_bytes=0,
+        )
 
     cutoff_ts = datetime.now(UTC).timestamp() - (retention_days * 24 * 60 * 60)
 
     total = 0
     older = 0
+    total_size = 0
+    older_size = 0
 
     try:
         for p in base.glob(search_pattern):
@@ -283,21 +295,27 @@ def _scan_folder(
 
             total += 1
             try:
-                if p.stat().st_mtime < cutoff_ts:
+                stat_info = p.stat()  # Get stat once for both mtime and size
+                total_size += stat_info.st_size
+                if stat_info.st_mtime < cutoff_ts:
                     older += 1
+                    older_size += stat_info.st_size
             except FileNotFoundError:
                 # Race condition: file was deleted between glob and stat
                 _LOGGER.debug(
                     "File disappeared during scan (race condition): %s", p.name
                 )
                 total -= 1  # Don't count files that no longer exist
+                # Don't add to size counters - file doesn't exist
             except PermissionError as err:
                 _LOGGER.warning("No permission to access file %s: %s", p.name, err)
-                # Keep file counted but can't check age
+                # Keep file counted but can't check age or size
+                # Don't add to size counters - can't determine size
             except OSError as err:
                 # Other OS errors (network issues, etc)
                 _LOGGER.debug("Cannot stat file %s: %s", p.name, err)
-                # Keep file counted but can't check age
+                # Keep file counted but can't check age or size
+                # Don't add to size counters - can't determine size
     except PermissionError as e:
         _LOGGER.error("No permission to access directory %s: %s", base_path, str(e))
         raise RuntimeError(f"Permission denied accessing {base_path}") from e
@@ -306,14 +324,20 @@ def _scan_folder(
         raise RuntimeError(f"Scan failed: {e!s}") from e
 
     _LOGGER.debug(
-        "Scan complete for %s: %d total files, %d older than %d days",
+        "Scan complete for %s: %d total files (%d bytes), %d older than %d days (%d bytes)",
         base_path,
         total,
+        total_size,
         older,
         retention_days,
+        older_size,
     )
     return ScanResult(
-        total_files=total, older_than_retention=older, path_available=True
+        total_files=total,
+        older_than_retention=older,
+        path_available=True,
+        total_size_bytes=total_size,
+        older_than_retention_size_bytes=older_size,
     )
 
 
@@ -1197,4 +1221,6 @@ class RetentionCleanerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "last_cleanup": self.last_cleanup,
             "last_scan_duration_ms": self.last_scan_duration_ms,
             "last_cleanup_duration_ms": self.last_cleanup_duration_ms,
+            "total_folder_size_bytes": result.total_size_bytes,
+            "older_than_retention_size_bytes": result.older_than_retention_size_bytes,
         }

--- a/custom_components/retention_cleaner/sensor.py
+++ b/custom_components/retention_cleaner/sensor.py
@@ -49,6 +49,24 @@ SENSOR_DEFS = [
         SensorStateClass.MEASUREMENT,
     ),
     (
+        "total_folder_size_bytes",
+        "Total Folder Size Bytes",
+        UnitOfInformation.BYTES,
+        "mdi:folder-multiple",
+        None,
+        SensorDeviceClass.DATA_SIZE,
+        SensorStateClass.MEASUREMENT,
+    ),
+    (
+        "older_than_retention_size_bytes",
+        "Older Than Retention Size Bytes",
+        UnitOfInformation.BYTES,
+        "mdi:delete-clock",
+        None,
+        SensorDeviceClass.DATA_SIZE,
+        SensorStateClass.MEASUREMENT,
+    ),
+    (
         "last_scan",
         "Last scan",
         None,
@@ -202,6 +220,8 @@ class RetentionCleanerSensor(
                 "older_than_retention",
                 "deleted_last_run",
                 "deleted_bytes_last_run",
+                "total_folder_size_bytes",
+                "older_than_retention_size_bytes",
                 "last_scan_duration_ms",
                 "last_cleanup_duration_ms",
             ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,11 @@ TEST_DIR_DEPTH_SHALLOW = 1
 TEST_DIR_DEPTH_MEDIUM = 3
 TEST_DIR_DEPTH_DEEP = 5
 
+# File size constants (bytes) for size sensor tests
+TEST_FILE_SIZE_SMALL = 1024  # 1 KB
+TEST_FILE_SIZE_MEDIUM = 102400  # 100 KB
+TEST_FILE_SIZE_LARGE = 1048576  # 1 MB
+
 
 def pytest_configure(config):
     """Configure pytest - ensures custom_components is in sys.path early."""
@@ -274,6 +279,8 @@ def mock_coordinator_data():
         "last_scan_duration_ms": 150,  # int milliseconds
         "last_cleanup_duration_ms": 500,  # int milliseconds
         "path_available": True,
+        "total_folder_size_bytes": 2097152,  # 2 MB
+        "older_than_retention_size_bytes": 1048576,  # 1 MB
     }
 
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -847,6 +847,312 @@ async def test_path_traversal_attack_prevention():
             # Rejection is also acceptable for security
             assert "base_path_not_media" in str(exc_info)
 
+
+# ============================================================================
+# FOLDER SIZE BYTE SENSORS - TDD TESTS
+# ============================================================================
+
+
+async def test_scan_result_accepts_size_bytes_fields():
+    """Test ScanResult dataclass accepts size byte fields."""
+    from custom_components.retention_cleaner.coordinator import ScanResult
+
+    result = ScanResult(
+        total_files=10,
+        older_than_retention=5,
+        path_available=True,
+        total_size_bytes=2097152,
+        older_than_retention_size_bytes=1048576,
+    )
+
+    assert result.total_files == 10, "Should store total_files count"
+    assert result.older_than_retention == 5, "Should store older_than_retention count"
+    assert result.path_available is True, "Should store path_available status"
+    assert result.total_size_bytes == 2097152, "Should store total size in bytes"
+    assert (
+        result.older_than_retention_size_bytes == 1048576
+    ), "Should store old files size in bytes"
+
+
+async def test_scan_result_size_bytes_default_to_zero():
+    """Test ScanResult size byte fields default to 0."""
+    from custom_components.retention_cleaner.coordinator import ScanResult
+
+    result = ScanResult(
+        total_files=10,
+        older_than_retention=5,
+        path_available=True,
+    )
+
+    assert result.total_size_bytes == 0, "Should default total_size_bytes to 0"
+    assert (
+        result.older_than_retention_size_bytes == 0
+    ), "Should default older_than_retention_size_bytes to 0"
+
+
+@pytest.mark.parametrize(
+    ("file_sizes", "file_ages_days", "expected_total_bytes", "expected_old_bytes"),
+    [
+        # Empty folder
+        ([], [], 0, 0),
+        # All files within retention (7 days)
+        ([1024, 2048, 4096], [2, 3, 5], 7168, 0),
+        # All files older than retention (8+ days old)
+        ([1024, 2048, 4096], [8, 9, 10], 7168, 7168),
+        # Mixed ages - some old, some new
+        ([1024, 2048, 4096, 8192], [2, 8, 5, 10], 15360, 10240),
+        # Single file scenarios
+        ([1048576], [2], 1048576, 0),
+        ([1048576], [8], 1048576, 1048576),
+    ],
+    ids=[
+        "empty_folder",
+        "all_within_retention",
+        "all_older_than_retention",
+        "mixed_ages",
+        "single_new_file",
+        "single_old_file",
+    ],
+)
+async def test_scan_folder_returns_correct_size_bytes(
+    tmp_path,
+    file_sizes,
+    file_ages_days,
+    expected_total_bytes,
+    expected_old_bytes,
+):
+    """Test _scan_folder() returns correct byte sizes for various scenarios."""
+    from custom_components.retention_cleaner.coordinator import _scan_folder
+    from tests.conftest import TEST_RETENTION_DAYS
+
+    media_dir = tmp_path / "media" / "test"
+    media_dir.mkdir(parents=True)
+
+    for i, (size, age_days) in enumerate(zip(file_sizes, file_ages_days, strict=False)):
+        file_path = media_dir / f"test_{i}.jpg"
+        file_path.write_bytes(b"x" * size)
+
+        old_time = time_module.time() - (age_days * 24 * 60 * 60)
+        os.utime(file_path, (old_time, old_time))
+
+    result = _scan_folder(
+        str(media_dir),
+        "*.jpg",
+        TEST_RETENTION_DAYS,
+    )
+
+    assert (
+        result.total_size_bytes == expected_total_bytes
+    ), f"Should calculate total size as {expected_total_bytes} bytes"
+    assert (
+        result.older_than_retention_size_bytes == expected_old_bytes
+    ), f"Should calculate old files size as {expected_old_bytes} bytes"
+    assert result.total_files == len(file_sizes), "Should count correct number of files"
+
+
+async def test_scan_folder_size_bytes_with_extension_filters(tmp_path):
+    """Test size calculation respects extension filters."""
+    from custom_components.retention_cleaner.coordinator import _scan_folder
+    from tests.conftest import (
+        TEST_FILE_SIZE_LARGE,
+        TEST_FILE_SIZE_MEDIUM,
+        TEST_FILE_SIZE_SMALL,
+        TEST_RETENTION_DAYS,
+    )
+
+    media_dir = tmp_path / "media" / "test"
+    media_dir.mkdir(parents=True)
+
+    mp4_file = media_dir / "video.mp4"
+    mp4_file.write_bytes(b"x" * TEST_FILE_SIZE_LARGE)
+
+    jpg_file = media_dir / "photo.jpg"
+    jpg_file.write_bytes(b"x" * TEST_FILE_SIZE_MEDIUM)
+
+    log_file = media_dir / "debug.log"
+    log_file.write_bytes(b"x" * TEST_FILE_SIZE_SMALL)
+
+    old_time = time_module.time() - (8 * 24 * 60 * 60)
+    for file in [mp4_file, jpg_file, log_file]:
+        os.utime(file, (old_time, old_time))
+
+    result = _scan_folder(
+        str(media_dir),
+        "",
+        TEST_RETENTION_DAYS,
+        only_ext_set={".mp4", ".jpg"},
+    )
+
+    expected_size = TEST_FILE_SIZE_LARGE + TEST_FILE_SIZE_MEDIUM
+    assert (
+        result.total_size_bytes == expected_size
+    ), "Should only count .mp4 and .jpg file sizes"
+    assert result.total_files == 2, "Should only count filtered files"
+
+
+async def test_scan_folder_size_bytes_file_not_found_error(tmp_path):
+    """Test size calculation handles FileNotFoundError during stat."""
+    from custom_components.retention_cleaner.coordinator import _scan_folder
+    from tests.conftest import TEST_RETENTION_DAYS
+
+    with patch(
+        "custom_components.retention_cleaner.coordinator.Path"
+    ) as mock_path_class:
+        mock_base = Mock()
+        mock_path_class.return_value = mock_base
+
+        mock_base.exists.return_value = True
+        mock_base.is_dir.return_value = True
+
+        mock_file1 = Mock()
+        mock_file1.is_file.return_value = True
+        mock_file1.name = "file1.jpg"
+        mock_file1.suffix = ".jpg"
+        mock_file1.stat.side_effect = FileNotFoundError("File deleted during scan")
+
+        mock_base.glob.return_value = [mock_file1]
+
+        result = _scan_folder(
+            "/media/test",
+            "*.jpg",
+            TEST_RETENTION_DAYS,
+        )
+
+        assert result.total_size_bytes == 0, "Should not count size of missing file"
+        assert result.total_files == 0, "Should not count missing file"
+
+
+async def test_scan_folder_size_bytes_permission_error(tmp_path):
+    """Test size calculation handles PermissionError during stat."""
+    from custom_components.retention_cleaner.coordinator import _scan_folder
+    from tests.conftest import TEST_RETENTION_DAYS
+
+    with patch(
+        "custom_components.retention_cleaner.coordinator.Path"
+    ) as mock_path_class:
+        mock_base = Mock()
+        mock_path_class.return_value = mock_base
+
+        mock_base.exists.return_value = True
+        mock_base.is_dir.return_value = True
+
+        mock_file1 = Mock()
+        mock_file1.is_file.return_value = True
+        mock_file1.name = "restricted.jpg"
+        mock_file1.suffix = ".jpg"
+        mock_file1.stat.side_effect = PermissionError("No access")
+
+        mock_base.glob.return_value = [mock_file1]
+
+        result = _scan_folder(
+            "/media/test",
+            "*.jpg",
+            TEST_RETENTION_DAYS,
+        )
+
+        assert result.total_files == 1, "Should count file despite permission error"
+        assert result.total_size_bytes == 0, "Should not add size when stat fails"
+
+
+async def test_scan_folder_size_bytes_with_zero_size_files(tmp_path):
+    """Test size calculation handles zero-size files correctly."""
+    from custom_components.retention_cleaner.coordinator import _scan_folder
+    from tests.conftest import TEST_RETENTION_DAYS
+
+    media_dir = tmp_path / "media" / "test"
+    media_dir.mkdir(parents=True)
+
+    empty_file = media_dir / "empty.jpg"
+    empty_file.touch()
+
+    old_time = time_module.time() - (8 * 24 * 60 * 60)
+    os.utime(empty_file, (old_time, old_time))
+
+    result = _scan_folder(
+        str(media_dir),
+        "*.jpg",
+        TEST_RETENTION_DAYS,
+    )
+
+    assert result.total_files == 1, "Should count zero-size file"
+    assert (
+        result.total_size_bytes == 0
+    ), "Should correctly report 0 bytes for empty file"
+    assert (
+        result.older_than_retention_size_bytes == 0
+    ), "Should correctly report 0 bytes for old empty file"
+
+
+async def test_coordinator_returns_size_bytes_in_data_dict(
+    hass: HomeAssistant, mock_setup_entry, tmp_path
+):
+    """Test coordinator._async_update_data() returns size byte fields."""
+    from tests.conftest import TEST_FILE_SIZE_MEDIUM, TEST_FILE_SIZE_SMALL
+
+    media_dir = tmp_path / "media" / "test"
+    media_dir.mkdir(parents=True)
+
+    new_file = media_dir / "new.jpg"
+    new_file.write_bytes(b"x" * TEST_FILE_SIZE_SMALL)
+    new_time = time_module.time() - (2 * 24 * 60 * 60)
+    os.utime(new_file, (new_time, new_time))
+
+    old_file = media_dir / "old.jpg"
+    old_file.write_bytes(b"x" * TEST_FILE_SIZE_MEDIUM)
+    old_time = time_module.time() - (8 * 24 * 60 * 60)
+    os.utime(old_file, (old_time, old_time))
+
+    mock_setup_entry = MockConfigEntry(
+        domain="retention_cleaner",
+        title="Test Cleanup",
+        data={
+            **mock_setup_entry.data,
+            "base_path": str(media_dir),
+        },
+        entry_id="test_entry_123",
+    )
+
+    coordinator = RetentionCleanerCoordinator(hass, mock_setup_entry)
+
+    try:
+        await coordinator.async_refresh()
+        await hass.async_block_till_done()
+
+        assert coordinator.data is not None, "Coordinator should have data"
+        assert (
+            "total_folder_size_bytes" in coordinator.data
+        ), "Should include total_folder_size_bytes key"
+        assert (
+            "older_than_retention_size_bytes" in coordinator.data
+        ), "Should include older_than_retention_size_bytes key"
+
+        expected_total = TEST_FILE_SIZE_SMALL + TEST_FILE_SIZE_MEDIUM
+        assert (
+            coordinator.data["total_folder_size_bytes"] == expected_total
+        ), f"Should calculate total size as {expected_total}"
+        assert (
+            coordinator.data["older_than_retention_size_bytes"] == TEST_FILE_SIZE_MEDIUM
+        ), f"Should calculate old files size as {TEST_FILE_SIZE_MEDIUM}"
+
+    finally:
+        await coordinator.async_shutdown()
+
+
+async def test_cleanup_result_tracks_deleted_bytes_already_exists():
+    """Test that CleanupResult already has deleted_bytes field (existing feature)."""
+    from custom_components.retention_cleaner.config_flow import _validate_base_path
+    from custom_components.retention_cleaner.coordinator import CleanupResult
+
+    result = CleanupResult(
+        deleted=5,
+        total_after=10,
+        older_remaining=2,
+        path_available=True,
+        deleted_bytes=102400,
+    )
+
+    assert result.deleted_bytes == 102400, "CleanupResult should track deleted_bytes"
+
     # Valid paths should work
     valid_paths = [
         "/media/cameras",
@@ -857,9 +1163,9 @@ async def test_path_traversal_attack_prevention():
     ]
 
     for path in valid_paths:
-        result = _validate_base_path(path)
-        assert result.startswith("/media/")
-        assert not result.endswith("/")  # Should strip trailing slash
+        result_path = _validate_base_path(path)
+        assert result_path.startswith("/media/")
+        assert not result_path.endswith("/")  # Should strip trailing slash
 
 
 async def test_symlink_attack_prevention(tmp_path):
@@ -1769,6 +2075,7 @@ def test_scan_file_race_condition_handling():
         mock_file2.name = "file2.jpg"
         mock_stat2 = Mock()
         mock_stat2.st_mtime = time_module.time() - (8 * 24 * 60 * 60)
+        mock_stat2.st_size = 1024
         mock_file2.stat.return_value = mock_stat2
 
         mock_file3 = Mock()
@@ -1776,6 +2083,7 @@ def test_scan_file_race_condition_handling():
         mock_file3.name = "file3.jpg"
         mock_stat3 = Mock()
         mock_stat3.st_mtime = time_module.time() - (8 * 24 * 60 * 60)
+        mock_stat3.st_size = 2048
         mock_file3.stat.return_value = mock_stat3
 
         mock_base.glob.return_value = [mock_file1, mock_file2, mock_file3]
@@ -1825,6 +2133,7 @@ def test_scan_file_multiple_exception_types():
         mock_file_old.name = "old_file.jpg"
         mock_stat_old = Mock()
         mock_stat_old.st_mtime = time_module.time() - (8 * 24 * 60 * 60)
+        mock_stat_old.st_size = 4096
         mock_file_old.stat.return_value = mock_stat_old
 
         mock_file_new = Mock()
@@ -1832,6 +2141,7 @@ def test_scan_file_multiple_exception_types():
         mock_file_new.name = "new_file.jpg"
         mock_stat_new = Mock()
         mock_stat_new.st_mtime = time_module.time() - (2 * 24 * 60 * 60)
+        mock_stat_new.st_size = 512
         mock_file_new.stat.return_value = mock_stat_new
 
         mock_base.glob.return_value = [

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -384,3 +384,168 @@ async def test_sensor_restore_other_sensor_type(hass: HomeAssistant, init_integr
 
     entity._restored_last_state = "custom_value_123"
     assert entity.native_value == "custom_value_123"
+
+
+# ============================================================================
+# FOLDER SIZE BYTE SENSORS - TDD TESTS
+# ============================================================================
+
+
+async def test_total_folder_size_bytes_sensor_exists_in_registry(
+    hass: HomeAssistant, init_integration
+):
+    """Test total_folder_size_bytes sensor is created in entity registry."""
+    registry = er.async_get(hass)
+
+    entry = registry.async_get("sensor.test_cleanup_total_folder_size_bytes")
+    assert entry is not None, "total_folder_size_bytes sensor should exist"
+    assert (
+        entry.unique_id == f"{init_integration.entry_id}_total_folder_size_bytes"
+    ), "Should have correct unique_id format"
+
+
+async def test_older_than_retention_size_bytes_sensor_exists_in_registry(
+    hass: HomeAssistant, init_integration
+):
+    """Test older_than_retention_size_bytes sensor is created in entity registry."""
+    registry = er.async_get(hass)
+
+    entry = registry.async_get("sensor.test_cleanup_older_than_retention_size_bytes")
+    assert entry is not None, "older_than_retention_size_bytes sensor should exist"
+    assert (
+        entry.unique_id
+        == f"{init_integration.entry_id}_older_than_retention_size_bytes"
+    ), "Should have correct unique_id format"
+
+
+async def test_size_sensors_have_correct_device_class(
+    hass: HomeAssistant, init_integration
+):
+    """Test size byte sensors have DATA_SIZE device class."""
+    state_total = hass.states.get("sensor.test_cleanup_total_folder_size_bytes")
+    assert state_total is not None, "total_folder_size_bytes state should exist"
+    assert (
+        state_total.attributes.get("device_class") == SensorDeviceClass.DATA_SIZE
+    ), "Should have DATA_SIZE device class"
+
+    state_old = hass.states.get("sensor.test_cleanup_older_than_retention_size_bytes")
+    assert state_old is not None, "older_than_retention_size_bytes state should exist"
+    assert (
+        state_old.attributes.get("device_class") == SensorDeviceClass.DATA_SIZE
+    ), "Should have DATA_SIZE device class"
+
+
+async def test_size_sensors_have_correct_unit(hass: HomeAssistant, init_integration):
+    """Test size byte sensors have BYTES unit."""
+    state_total = hass.states.get("sensor.test_cleanup_total_folder_size_bytes")
+    assert state_total is not None, "total_folder_size_bytes state should exist"
+    assert (
+        state_total.attributes.get("unit_of_measurement") == UnitOfInformation.BYTES
+    ), "Should have BYTES unit"
+
+    state_old = hass.states.get("sensor.test_cleanup_older_than_retention_size_bytes")
+    assert state_old is not None, "older_than_retention_size_bytes state should exist"
+    assert (
+        state_old.attributes.get("unit_of_measurement") == UnitOfInformation.BYTES
+    ), "Should have BYTES unit"
+
+
+async def test_size_sensors_have_correct_state_class(
+    hass: HomeAssistant, init_integration
+):
+    """Test size byte sensors have MEASUREMENT state class."""
+    state_total = hass.states.get("sensor.test_cleanup_total_folder_size_bytes")
+    assert state_total is not None, "total_folder_size_bytes state should exist"
+    assert (
+        state_total.attributes.get("state_class") == SensorStateClass.MEASUREMENT
+    ), "Should have MEASUREMENT state class"
+
+    state_old = hass.states.get("sensor.test_cleanup_older_than_retention_size_bytes")
+    assert state_old is not None, "older_than_retention_size_bytes state should exist"
+    assert (
+        state_old.attributes.get("state_class") == SensorStateClass.MEASUREMENT
+    ), "Should have MEASUREMENT state class"
+
+
+async def test_size_sensors_update_from_coordinator_data(
+    hass: HomeAssistant, init_integration
+):
+    """Test size byte sensors update when coordinator data changes."""
+    from datetime import UTC, datetime
+
+    coordinator = init_integration.runtime_data
+
+    coordinator.data = {
+        "total_files": 100,
+        "older_than_retention": 25,
+        "deleted_last_run": 10,
+        "deleted_bytes_last_run": 102400,
+        "last_scan": datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC),
+        "last_cleanup": datetime(2024, 1, 1, 2, 0, 0, tzinfo=UTC),
+        "last_scan_duration_ms": 150,
+        "last_cleanup_duration_ms": 500,
+        "total_folder_size_bytes": 2097152,
+        "older_than_retention_size_bytes": 1048576,
+    }
+
+    coordinator.async_set_updated_data(coordinator.data)
+    await hass.async_block_till_done()
+
+    state_total = hass.states.get("sensor.test_cleanup_total_folder_size_bytes")
+    assert state_total.state == "2097152", "Should display total folder size in bytes"
+
+    state_old = hass.states.get("sensor.test_cleanup_older_than_retention_size_bytes")
+    assert state_old.state == "1048576", "Should display old files size in bytes"
+
+
+async def test_size_sensors_handle_missing_data(hass: HomeAssistant, init_integration):
+    """Test size byte sensors handle missing data gracefully."""
+    coordinator = init_integration.runtime_data
+
+    coordinator.data = {
+        "total_files": 50,
+    }
+
+    coordinator.async_set_updated_data(coordinator.data)
+    await hass.async_block_till_done()
+
+    state_total = hass.states.get("sensor.test_cleanup_total_folder_size_bytes")
+    assert state_total.state in [
+        "0",
+        "unknown",
+    ], "Should have safe default for missing total_folder_size_bytes"
+
+    state_old = hass.states.get("sensor.test_cleanup_older_than_retention_size_bytes")
+    assert state_old.state in [
+        "0",
+        "unknown",
+    ], "Should have safe default for missing older_than_retention_size_bytes"
+
+
+async def test_size_sensors_linked_to_device(hass: HomeAssistant, init_integration):
+    """Test size byte sensors are linked to the correct device."""
+    from custom_components.retention_cleaner.const import DOMAIN
+
+    registry = er.async_get(hass)
+
+    entry_total = registry.async_get("sensor.test_cleanup_total_folder_size_bytes")
+    assert entry_total is not None, "total_folder_size_bytes entry should exist"
+    assert entry_total.device_id is not None, "Should be linked to device"
+
+    entry_old = registry.async_get(
+        "sensor.test_cleanup_older_than_retention_size_bytes"
+    )
+    assert entry_old is not None, "older_than_retention_size_bytes entry should exist"
+    assert entry_old.device_id is not None, "Should be linked to device"
+
+    try:
+        device_registry = hass.helpers.device_registry.async_get()
+    except TypeError:
+        device_registry = hass.helpers.device_registry.async_get(hass)
+
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, init_integration.entry_id)}
+    )
+    assert device is not None, "Device should exist"
+    assert entry_total.device_id == device.id, "Should link to same device"
+    assert entry_old.device_id == device.id, "Should link to same device"


### PR DESCRIPTION
Add two new sensors to track storage usage:
- total_folder_size_bytes: Total size of all matched files
- older_than_retention_size_bytes: Size of files eligible for deletion

These sensors enable better storage monitoring and help predict cleanup impact. The implementation has zero performance overhead as it reuses existing stat() calls during file scanning.

Key features:
- Automatic unit conversion (KB/MB/GB) via DATA_SIZE device class
- Pattern and extension filter aware (only counts matched files)
- Dashboard and automation ready
- Graceful error handling (race conditions, permission errors)