### PR TITLE
fix: config flow validation error for extension filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.1.1] - 2026-01-26
+
+### Fixed
+- Config flow validation error when configuring extension filters with default pattern value. Users can now set Only Extensions or Except Extensions without manually clearing the pattern field.
+
 ## [1.1.0]
 
 ### Added
@@ -143,6 +148,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Config flow for UI configuration
 - Glob pattern support
 
+[1.1.1]: https://github.com/thomasgriebner/retention_cleaner/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/thomasgriebner/retention_cleaner/compare/v1.0.10...v1.1.0
 [1.0.10]: https://github.com/thomasgriebner/retention_cleaner/compare/v1.0.9...v1.0.10
 [1.0.9]: https://github.com/thomasgriebner/retention_cleaner/compare/v1.0.8...v1.0.9

--- a/custom_components/retention_cleaner/config_flow.py
+++ b/custom_components/retention_cleaner/config_flow.py
@@ -321,8 +321,15 @@ def _validate_pattern_and_extensions(user_input: dict) -> dict:
     only_ext = user_input.get(CONF_ONLY_EXTENSIONS, "").strip()
     except_ext = user_input.get(CONF_EXCEPT_EXTENSIONS, "").strip()
 
-    has_pattern = bool(pattern)
     has_extensions = bool(only_ext or except_ext)
+
+    # UX Fix: Treat DEFAULT_PATTERN as empty when extensions are provided
+    # This allows extension filters to override the default pattern value
+    # without requiring users to manually clear the field
+    if has_extensions and pattern == DEFAULT_PATTERN:
+        pattern = ""
+
+    has_pattern = bool(pattern)
 
     # Rule 1: At least one must be set
     if not has_pattern and not has_extensions:

--- a/custom_components/retention_cleaner/manifest.json
+++ b/custom_components/retention_cleaner/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://github.com/thomasgriebner/retention_cleaner",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/thomasgriebner/retention_cleaner/issues",
-  "version": "1.1.0"
+  "version": "1.1.1"
 }

--- a/tests/test_extension_filtering.py
+++ b/tests/test_extension_filtering.py
@@ -14,6 +14,7 @@ from custom_components.retention_cleaner.const import (
     CONF_PATTERN,
     CONF_RETENTION_DAYS,
     CONF_RUN_AT,
+    DEFAULT_PATTERN,
 )
 from custom_components.retention_cleaner.coordinator import (
     RetentionCleanerCoordinator,
@@ -324,6 +325,48 @@ class TestConfigFlowMutualExclusion:
             result["type"] == FlowResultType.CREATE_ENTRY
         ), "Should allow empty pattern in extension mode"
         assert result["data"][CONF_PATTERN] == "", "Pattern should be empty"
+
+    @pytest.mark.parametrize(
+        "extension_field,extension_value",
+        [
+            (CONF_ONLY_EXTENSIONS, ".mp4,.mkv"),
+            (CONF_EXCEPT_EXTENSIONS, ".log,.tmp"),
+        ],
+    )
+    async def test_default_pattern_with_extensions_should_succeed(
+        self,
+        hass: HomeAssistant,
+        extension_config_flow,
+        extension_field,
+        extension_value,
+    ) -> None:
+        """Test that DEFAULT_PATTERN is overridden when extensions are provided.
+
+        Bug: Users get 'cannot_combine_pattern_and_extensions' error when they
+        set extension filters with the default pattern value. The default should
+        be treated as 'not set' to allow extension filters to work.
+        """
+        result = await extension_config_flow(
+            {
+                CONF_BASE_PATH: TEST_MEDIA_PATH,
+                CONF_PATTERN: DEFAULT_PATTERN,
+                extension_field: extension_value,
+                CONF_RETENTION_DAYS: TEST_RETENTION_DAYS,
+                CONF_DRY_RUN: True,
+                CONF_MAX_DELETES: TEST_MAX_DELETES,
+                CONF_RUN_AT: TEST_RUN_AT,
+            }
+        )
+
+        assert (
+            result["type"] == FlowResultType.CREATE_ENTRY
+        ), f"Should allow extensions to override DEFAULT_PATTERN (got error: {result.get('errors', {})})"
+        assert (
+            result["data"][CONF_PATTERN] == ""
+        ), "Pattern should be empty when extensions used"
+        assert (
+            result["data"][extension_field] == extension_value
+        ), f"Extension filter should be set to {extension_value}"
 
 
 class TestOptionsFlowExtensions:


### PR DESCRIPTION
Treat DEFAULT_PATTERN as empty when extensions are provided. This allows users to configure only_extensions/except_extensions without manually clearing the pattern field.

- config_flow.py: Override DEFAULT_PATTERN in _validate_pattern_and_extensions()
- test_extension_filtering.py: Add test case for default pattern with extensions
- manifest.json: Bump to v1.1.1
- CHANGELOG.md: Document fix