### PR TITLE
feat: runtime configuration entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,53 +7,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [1.2.0] - 2026-02-03
 
 ### Added
-- Configuration entities for runtime-editable configuration without restarting Home Assistant
-  - **Number entities (4)**:
-    - `retention_days` (1-3650 days) - Change retention period via UI, triggers immediate scan
-    - `max_deletes` (1-10,000 files) - Maximum files to delete per cleanup run
-    - `keep_minimum_files` (0-10,000 files) - Minimum files to always preserve
-    - `max_files_in_folder` (0-1,000,000 files) - Maximum total files trigger cleanup
-  - **Switch entities (2)**:
-    - `dry_run` (on/off) - Toggle simulation mode without triggering scan (migrated from Select)
-    - `remove_empty_folders` (on/off) - Auto-remove empty directories after cleanup
-  - **Text entities (3)**:
-    - `pattern` - Edit glob pattern (e.g., `**/*.jpg`) with validation against dangerous patterns
-    - `only_extensions` - Comma-separated include list for file extensions (e.g., `.mp4,.jpg`)
-    - `except_extensions` - Comma-separated exclude list for file extensions (e.g., `.tmp,.log`)
-    - All text entities validate input (extension format, pattern safety) and enforce mutual exclusion rules
-  - **Time entity (1)**:
-    - `run_at` (HH:MM format) - Change daily cleanup time, automatically reschedules next cleanup
-  - **Sensor (1)**:
-    - `base_path` (read-only, diagnostic category) - Displays configured base path
-  - All config entities use `EntityCategory.CONFIG` for proper UI grouping (except base_path sensor which uses DIAGNOSTIC)
-- ConfigSnapshot pattern for race-condition prevention during cleanup operations
-  - Immutable config snapshots captured at start of scan/cleanup operations
-  - Configuration changes during operations don't affect in-progress scans/cleanups
-  - Changes take effect on next operation for consistency
-- Live configuration updates trigger immediate coordinator refresh
-  - Number, Text, and Time entity changes trigger automatic scan to update file counts
-  - Switch entity changes update config only (no scan needed)
-  - Changes are atomic and immediately persisted via `async_update_config_value()`
-- Cross-field validation for pattern and extension mutual exclusion
-  - Prevents simultaneous use of custom pattern with extension filters
-  - Enforces only_extensions OR except_extensions, not both
-  - Validation enforced at both config flow and entity update time
+- Runtime configuration entities for editing settings without restarting Home Assistant
+  - **Number entities**: `retention_days`, `max_deletes`, `keep_minimum_files`, `max_files_in_folder`
+  - **Switch entities**: `dry_run`, `remove_empty_folders`
+  - **Text entities**: `pattern`, `only_extensions`, `except_extensions` (with input validation)
+  - **Time entity**: `run_at` for changing daily cleanup schedule
+  - **Sensor**: `base_path` (read-only, diagnostic)
+  - Changes to number, text, and time entities trigger immediate scan to update file counts
+  - Switch entity changes apply immediately without triggering scan
 
 ### Changed
-- Migrated `dry_run` from Select entity (Off/On options) to Switch entity (on/off) for better user experience
-- Sensor entities no longer expose configuration as attributes (`base_path`, `pattern`, `retention_days` removed from sensor attributes)
-- Configuration now managed through dedicated config entities for frequently changed values
-- Options flow remains for initial setup, but runtime changes use config entities
-- Sensor units: `suggested_unit_of_measurement=MEGABYTES` with `precision=2` for deleted_bytes sensors
-- Test coverage improved to 99.17% with 416 comprehensive tests including new entity platforms
-- All entity platforms now properly integrated (number, switch, text, time, sensor platforms)
+- `dry_run` migrated from Select entity to Switch entity for better user experience
+- Configuration values moved from sensor attributes to dedicated config entities
+- Deleted bytes sensors now display in MB with 2 decimal places
+
+### Fixed
+- Number configuration entities now return integer values instead of float, preventing decimal separators (commas) in localized Home Assistant UIs
 
 ### Breaking Changes
 - **Removed sensor attributes**: `base_path`, `pattern`, and `retention_days` no longer available as sensor extra_state_attributes
   - Migration: Use the new config entities instead (automatically created for all instances)
-  - `base_path` is now a separate diagnostic sensor entity (read-only)
-  - `pattern` is now an editable text entity (triggers scan on change)
-  - `retention_days` is now an editable number entity (triggers scan on change)
   - Existing automations or templates reading sensor attributes must be updated to use new entity IDs
 
 ## [1.1.1] - 2026-01-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,58 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.2.0] - 2026-02-03
+
+### Added
+- Configuration entities for runtime-editable configuration without restarting Home Assistant
+  - **Number entities (4)**:
+    - `retention_days` (1-3650 days) - Change retention period via UI, triggers immediate scan
+    - `max_deletes` (1-10,000 files) - Maximum files to delete per cleanup run
+    - `keep_minimum_files` (0-10,000 files) - Minimum files to always preserve
+    - `max_files_in_folder` (0-1,000,000 files) - Maximum total files trigger cleanup
+  - **Switch entities (2)**:
+    - `dry_run` (on/off) - Toggle simulation mode without triggering scan (migrated from Select)
+    - `remove_empty_folders` (on/off) - Auto-remove empty directories after cleanup
+  - **Text entities (3)**:
+    - `pattern` - Edit glob pattern (e.g., `**/*.jpg`) with validation against dangerous patterns
+    - `only_extensions` - Comma-separated include list for file extensions (e.g., `.mp4,.jpg`)
+    - `except_extensions` - Comma-separated exclude list for file extensions (e.g., `.tmp,.log`)
+    - All text entities validate input (extension format, pattern safety) and enforce mutual exclusion rules
+  - **Time entity (1)**:
+    - `run_at` (HH:MM format) - Change daily cleanup time, automatically reschedules next cleanup
+  - **Sensor (1)**:
+    - `base_path` (read-only, diagnostic category) - Displays configured base path
+  - All config entities use `EntityCategory.CONFIG` for proper UI grouping (except base_path sensor which uses DIAGNOSTIC)
+- ConfigSnapshot pattern for race-condition prevention during cleanup operations
+  - Immutable config snapshots captured at start of scan/cleanup operations
+  - Configuration changes during operations don't affect in-progress scans/cleanups
+  - Changes take effect on next operation for consistency
+- Live configuration updates trigger immediate coordinator refresh
+  - Number, Text, and Time entity changes trigger automatic scan to update file counts
+  - Switch entity changes update config only (no scan needed)
+  - Changes are atomic and immediately persisted via `async_update_config_value()`
+- Cross-field validation for pattern and extension mutual exclusion
+  - Prevents simultaneous use of custom pattern with extension filters
+  - Enforces only_extensions OR except_extensions, not both
+  - Validation enforced at both config flow and entity update time
+
+### Changed
+- Migrated `dry_run` from Select entity (Off/On options) to Switch entity (on/off) for better user experience
+- Sensor entities no longer expose configuration as attributes (`base_path`, `pattern`, `retention_days` removed from sensor attributes)
+- Configuration now managed through dedicated config entities for frequently changed values
+- Options flow remains for initial setup, but runtime changes use config entities
+- Sensor units: `suggested_unit_of_measurement=MEGABYTES` with `precision=2` for deleted_bytes sensors
+- Test coverage improved to 99.17% with 416 comprehensive tests including new entity platforms
+- All entity platforms now properly integrated (number, switch, text, time, sensor platforms)
+
+### Breaking Changes
+- **Removed sensor attributes**: `base_path`, `pattern`, and `retention_days` no longer available as sensor extra_state_attributes
+  - Migration: Use the new config entities instead (automatically created for all instances)
+  - `base_path` is now a separate diagnostic sensor entity (read-only)
+  - `pattern` is now an editable text entity (triggers scan on change)
+  - `retention_days` is now an editable number entity (triggers scan on change)
+  - Existing automations or templates reading sensor attributes must be updated to use new entity IDs
+
 ## [1.1.1] - 2026-01-26
 
 ### Fixed
@@ -148,6 +200,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Config flow for UI configuration
 - Glob pattern support
 
+[1.2.0]: https://github.com/thomasgriebner/retention_cleaner/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/thomasgriebner/retention_cleaner/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/thomasgriebner/retention_cleaner/compare/v1.0.10...v1.1.0
 [1.0.10]: https://github.com/thomasgriebner/retention_cleaner/compare/v1.0.9...v1.0.10

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Your Frigate camera fills up `/media/` with recordings. Instead of SSHing in and
 ## Features
 
 - **Rule-Based Cleanup** - Each device represents one folder with its own retention policy
+- **Runtime Configuration** - Change retention days, patterns, and schedules via UI without restarting (v1.2.0+)
 - **Automated Scheduling** - Daily cleanup runs at your specified time
 - **Safety First** - Dry-run mode, delete limits, and path restrictions protect against accidents
 - **Performance Tracking** - Monitor scan/cleanup duration and deleted file sizes
@@ -58,21 +59,188 @@ Your Frigate camera fills up `/media/` with recordings. Instead of SSHing in and
 
 ## Configuration
 
-Each cleanup rule creates a device with the following configuration options:
+Each cleanup rule creates a device with the following configuration options. **New in v1.2.0:** Most configuration parameters can now be changed at runtime through dedicated config entities without restarting Home Assistant.
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| **Base Path** | string | - | Root directory to clean (must start with `/media/` or `/share/`) |
-| **File Pattern** | string | `**/*.jpg` | Glob pattern for matching files |
-| **Retention Days** | integer | `30` | Keep files newer than this many days (max: 3650 / 10 years) |
-| **Cleanup Time** | time | `03:15` | Daily automatic cleanup schedule (HH:MM) |
-| **Dry Run** | boolean | `false` | Test mode - count files without deleting |
-| **Max Deletes** | integer | `5000` | Safety limit per cleanup run |
-| **Only Extensions** | string | - | Keep only files with these extensions (e.g., `.mp4,.avi`) - case-insensitive |
-| **Except Extensions** | string | - | Delete all files except these extensions (e.g., `.log,.tmp`) - case-insensitive |
-| **Keep Minimum Files** | integer | `0` | Always preserve this many newest files (0-10,000), regardless of retention |
-| **Max Files In Folder** | integer | `0` | Cap total number of files in folder (0-1,000,000), enforced after time-based cleanup (0 = disabled) |
-| **Remove Empty Folders** | boolean | `false` | Remove empty subdirectories after file deletion (opt-in for safety) |
+| Parameter | Type | Default | Editable | Description |
+|-----------|------|---------|----------|-------------|
+| **Base Path** | string | - | No (Setup only) | Root directory to clean (must start with `/media/` or `/share/`) |
+| **File Pattern** | string | `**/*.jpg` | **Yes** (Text entity) | Glob pattern for matching files |
+| **Retention Days** | integer | `30` | **Yes** (Number entity) | Keep files newer than this many days (1-3650) |
+| **Cleanup Time** | time | `03:15` | **Yes** (Time entity) | Daily automatic cleanup schedule (HH:MM) |
+| **Dry Run** | boolean | `false` | **Yes** (Switch entity) | Test mode - count files without deleting |
+| **Max Deletes** | integer | `5000` | **Yes** (Number entity) | Safety limit per cleanup run (1-10,000) |
+| **Only Extensions** | string | - | **Yes** (Text entity) | Keep only files with these extensions (e.g., `.mp4,.avi`) - case-insensitive |
+| **Except Extensions** | string | - | **Yes** (Text entity) | Delete all files except these extensions (e.g., `.log,.tmp`) - case-insensitive |
+| **Keep Minimum Files** | integer | `0` | **Yes** (Number entity) | Always preserve this many newest files (0-10,000), regardless of retention |
+| **Max Files In Folder** | integer | `0` | **Yes** (Number entity) | Cap total number of files in folder (0-1,000,000), enforced after time-based cleanup (0 = disabled) |
+| **Remove Empty Folders** | boolean | `false` | **Yes** (Switch entity) | Remove empty subdirectories after file deletion (opt-in for safety) |
+
+### Configuration Entities (Runtime Configuration)
+
+**New in v1.2.0:** Change key configuration parameters at runtime through the Home Assistant UI without restarting. These entities appear automatically for each cleanup rule under the device.
+
+#### Why Configuration Entities?
+
+Previously, changing configuration required using the options flow dialog. Now you can:
+- **Change settings instantly** via the UI - no dialog navigation required
+- **Automate configuration** - trigger config changes from automations
+- **Test retention periods** - quickly adjust retention days to preview cleanup impact
+- **Schedule cleanup times** - change daily cleanup schedule without reconfiguration
+- **Enable/disable features** - toggle dry-run mode or empty folder removal with a switch
+
+**Config Entities vs Options Flow:**
+- **Config entities** are for frequently changed values (retention days, pattern, cleanup time, dry-run mode)
+- **Options flow** remains for initial setup and device configuration
+- Changes via config entities are immediate and trigger automatic updates
+- All config entities are atomic and immediately persisted to storage
+
+#### Available Configuration Entities (9 Total)
+
+**Number Entities (4):**
+
+| Entity | Range | Default | Behavior on Change | Description |
+|--------|-------|---------|-------------------|-------------|
+| **Retention days** | 1-3650 days | 30 | Triggers immediate scan | How many days to keep files before deletion |
+| **Max deletes** | 1-10,000 files | 5000 | No scan triggered | Safety limit per cleanup run |
+| **Keep minimum files** | 0-10,000 files | 0 | No scan triggered | Always preserve this many newest files |
+| **Max files in folder** | 0-1,000,000 files | 0 | No scan triggered | Cap total files (0 = disabled) |
+
+**Switch Entities (2):**
+
+| Entity | Default | Behavior on Change | Description |
+|--------|---------|-------------------|-------------|
+| **Dry run** | Off | No scan triggered | Toggle simulation mode (migrated from Select in v1.2.0) |
+| **Remove empty folders** | Off | No scan triggered | Auto-remove empty directories after cleanup |
+
+**Text Entities (3):**
+
+| Entity | Default | Behavior on Change | Description |
+|--------|---------|-------------------|-------------|
+| **Pattern** | `**/*.jpg` | Triggers immediate scan | File matching pattern with validation |
+| **Only extensions** | Empty | Triggers immediate scan | Comma-separated include list (e.g., `.mp4,.jpg`) |
+| **Except extensions** | Empty | Triggers immediate scan | Comma-separated exclude list (e.g., `.tmp,.log`) |
+
+**Time Entity (1):**
+
+| Entity | Default | Behavior on Change | Description |
+|--------|---------|-------------------|-------------|
+| **Run at** | 03:15 | Reschedules next cleanup | Daily automatic cleanup time (HH:MM) |
+
+**Sensor (1):**
+
+| Entity | Category | Description |
+|--------|----------|-------------|
+| **Base Path** | Diagnostic | Read-only display of configured base path |
+
+#### Validation and Safety
+
+**Pattern Validation:**
+- Dangerous patterns like `*` or `**/*` are rejected
+- Prevents accidental deletion of all files
+- Invalid syntax (e.g., `***`) is blocked
+
+**Extension Validation:**
+- Extensions must start with dot (e.g., `.mp4` not `mp4`)
+- No wildcards allowed in extensions
+- Must have at least one character after dot
+
+**Mutual Exclusion:**
+- Cannot use custom pattern with extension filters simultaneously
+- Cannot set both `only_extensions` and `except_extensions`
+- UI validates before saving changes
+
+#### Usage Examples
+
+**Change Retention Period via UI:**
+```yaml
+# Navigate to device page, find "Retention days" number entity
+# Adjust slider from 30 to 14 days
+# Scan triggers automatically to show new file counts
+```
+
+**Automate Retention Adjustment:**
+```yaml
+automation:
+  - alias: "Reduce retention when disk space low"
+    trigger:
+      - platform: numeric_state
+        entity_id: sensor.disk_use_percent
+        above: 85
+    action:
+      - service: number.set_value
+        target:
+          entity_id: number.front_camera_retention_days
+        data:
+          value: 7  # Temporarily reduce to 7 days
+```
+
+**Toggle Dry-Run for Testing:**
+```yaml
+# Before testing new pattern, enable dry-run
+# Navigate to device page, find "Dry run" switch entity
+# Toggle switch to "On"
+# Run cleanup button to see what would be deleted
+# Toggle switch to "Off" when ready
+```
+
+**Automate Dry-Run Toggle:**
+```yaml
+automation:
+  - alias: "Enable dry-run during work hours"
+    trigger:
+      - platform: time
+        at: "09:00:00"
+    action:
+      - service: switch.turn_on
+        target:
+          entity_id: switch.front_camera_dry_run
+  - alias: "Disable dry-run at night"
+    trigger:
+      - platform: time
+        at: "22:00:00"
+    action:
+      - service: switch.turn_off
+        target:
+          entity_id: switch.front_camera_dry_run
+```
+
+**Change Daily Cleanup Time:**
+```yaml
+automation:
+  - alias: "Switch cleanup time for winter"
+    trigger:
+      - platform: time
+        at: "00:00:00"
+    condition:
+      - condition: template
+        value_template: "{{ now().month in [11, 12, 1, 2] }}"  # Winter months
+    action:
+      - service: time.set_value
+        target:
+          entity_id: time.front_camera_run_at
+        data:
+          time: "04:00:00"  # Later cleanup in winter
+```
+
+#### Technical Implementation
+
+**ConfigSnapshot Pattern:**
+Configuration changes are handled through immutable snapshots during operations:
+- Scan/cleanup operations use snapshot of config at start time
+- Prevents race conditions when config changes mid-operation
+- Changes take effect on next operation (scan/cleanup)
+
+**Atomic Updates:**
+All configuration changes are atomic and immediately persisted:
+1. Entity value changes via UI or service call
+2. Validation runs (syntax, cross-field rules)
+3. Config entry updated (persisted to storage)
+4. Coordinator refreshes (entities update)
+5. Scheduler updates (if time entity changed)
+
+**Order of Operations:**
+1. Number/Text/Time entity change → Triggers coordinator refresh → Triggers automatic scan
+2. Select entity (dry-run) change → Updates config only (no scan needed)
 
 ### Pattern Examples
 
@@ -274,20 +442,38 @@ With this configuration:
 
 Each cleanup rule provides these entities:
 
+### Configuration Entities (New in v1.2.0)
+
+| Entity | Type | Category | Description |
+|--------|------|----------|-------------|
+| **Retention days** | Number | CONFIG | Editable retention period (1-3650 days), triggers scan on change |
+| **Max deletes** | Number | CONFIG | Editable safety limit (1-10,000 files) per cleanup run |
+| **Keep minimum files** | Number | CONFIG | Editable minimum files to preserve (0-10,000) |
+| **Max files in folder** | Number | CONFIG | Editable maximum total files (0-1,000,000, 0 = disabled) |
+| **Dry run** | Switch | CONFIG | Toggle simulation mode (on/off), migrated from Select in v1.2.0 |
+| **Remove empty folders** | Switch | CONFIG | Toggle empty directory removal (on/off) |
+| **Pattern** | Text | CONFIG | Editable glob pattern, triggers scan on change |
+| **Only extensions** | Text | CONFIG | Include filter for extensions, triggers scan on change |
+| **Except extensions** | Text | CONFIG | Exclude filter for extensions, triggers scan on change |
+| **Run at** | Time | CONFIG | Editable daily cleanup time (HH:MM), reschedules on change |
+| **Base Path** | Sensor | DIAGNOSTIC | Read-only display of configured path |
+
+See [Configuration Entities](#configuration-entities-runtime-configuration) section for detailed usage.
+
 ### Sensors
 
-| Entity | Description | Unit |
-|--------|-------------|------|
-| **Total files** | Current file count | files |
-| **Older than retention** | Files eligible for deletion | files |
-| **Deleted last cleanup** | Files deleted in last run | files |
-| **Deleted bytes last cleanup** | Size of deleted files | bytes |
-| **Total folder size bytes** | Total size of all matched files | bytes |
-| **Older than retention size bytes** | Size of files eligible for deletion | bytes |
-| **Last scan** | Timestamp of last scan | - |
-| **Last cleanup** | Timestamp of last cleanup | - |
-| **Last scan duration** | Performance metric | ms |
-| **Last cleanup duration** | Performance metric | ms |
+| Entity | Description | Unit | Category |
+|--------|-------------|------|----------|
+| **Total files** | Current file count | files | - |
+| **Older than retention** | Files eligible for deletion | files | - |
+| **Deleted last cleanup** | Files deleted in last run | files | - |
+| **Deleted bytes last cleanup** | Size of deleted files | bytes | - |
+| **Total folder size bytes** | Total size of all matched files | bytes | - |
+| **Older than retention size bytes** | Size of files eligible for deletion | bytes | - |
+| **Last scan** | Timestamp of last scan | - | DIAGNOSTIC |
+| **Last cleanup** | Timestamp of last cleanup | - | DIAGNOSTIC |
+| **Last scan duration** | Performance metric | ms | DIAGNOSTIC |
+| **Last cleanup duration** | Performance metric | ms | DIAGNOSTIC |
 
 ### Binary Sensor
 
@@ -498,6 +684,8 @@ Create multiple cleanup rules for different folders by adding the integration mu
 | Extension filter not working | Ensure no File Pattern is set (use default `**/*.jpg` or leave empty) |
 | Still has old files | Check if Keep Minimum Files is protecting them |
 | Cannot set both extension filters | Use only `only_extensions` OR `except_extensions`, not both |
+| Missing sensor attributes (v1.2.0+) | Configuration values moved to dedicated config entities (see device page) |
+| Config changes not taking effect | Changes trigger automatic scan; check entity update time and scan sensor |
 
 For more help, check the [issue tracker](https://github.com/thomasgriebner/retention_cleaner/issues).
 

--- a/README.md
+++ b/README.md
@@ -5,29 +5,22 @@
 [![License](https://img.shields.io/github/license/thomasgriebner/retention_cleaner.svg)](LICENSE)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/thomasgriebner/retention_cleaner/graphs/commit-activity)
 
-Automatically clean up old files in Home Assistant based on configurable retention rules. Perfect for managing camera recordings, snapshots, and logs.
+Automatically clean up old files in Home Assistant based on retention rules. Perfect for managing camera recordings, snapshots, and backups without SSH or cron jobs.
 
-> **⚠️ Important:** This integration permanently deletes files. Always test with dry-run mode first and verify your configuration before enabling automated cleanup.
-
-## Why this Integration?
-
-Managing disk space on Home Assistant usually means SSH access, cron jobs, and custom shell scripts. If your camera recordings are filling up your storage, you'd typically write a bash script, schedule it with cron, and hope it doesn't accidentally delete the wrong files. There's no visibility in Home Assistant, no way to test safely, and troubleshooting means digging through system logs.
-
-Configure cleanup rules directly in the Home Assistant UI with no shell access required. Test your configuration safely with dry-run mode and see exactly what will be deleted before committing. Monitor storage usage, track cleanup history, and get real-time alerts when paths become inaccessible - all from your Home Assistant dashboard.
-
-Your Frigate camera fills up `/media/` with recordings. Instead of SSHing in and writing a bash script to delete old files, just add this integration, set your retention days, enable dry-run mode to verify, and let Home Assistant handle it automatically. You'll see sensor updates showing how much storage was freed and can even set up automations based on file counts or folder sizes.
-
----
+> **⚠️ Important:** This integration permanently deletes files. Always test with dry-run mode first.
 
 ## Features
 
-- **Rule-Based Cleanup** - Each device represents one folder with its own retention policy
-- **Runtime Configuration** - Change retention days, patterns, and schedules via UI without restarting (v1.2.0+)
-- **Automated Scheduling** - Daily cleanup runs at your specified time
-- **Safety First** - Dry-run mode, delete limits, and path restrictions protect against accidents
-- **Performance Tracking** - Monitor scan/cleanup duration and deleted file sizes
-- **Manual Control** - Test rules with scan/cleanup buttons before automation
-- **Full UI Configuration** - No YAML editing required
+- Configurable retention policies per folder
+- Runtime configuration via UI entities (no restart needed)
+- Daily automated cleanup scheduling
+- Dry-run mode for safe testing
+- Extension filtering (include/exclude specific file types)
+- Minimum file protection and maximum file limits
+- Automatic empty directory cleanup
+- Storage monitoring sensors
+- Manual scan and cleanup buttons
+- Path safety restrictions (`/media/` and `/share/` only)
 
 ---
 
@@ -37,128 +30,66 @@ Your Frigate camera fills up `/media/` with recordings. Instead of SSHing in and
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=thomasgriebner&repository=retention_cleaner&category=integration)
 
-1. Click the badge above or open **HACS** → **Integrations**
+1. Open **HACS** → **Integrations**
 2. Search for **Retention Cleaner**
 3. Click **Download**
 4. Restart Home Assistant
 
 ### Manual Installation
 
-1. Copy `custom_components/retention_cleaner` to your Home Assistant's `custom_components` directory
+1. Copy `custom_components/retention_cleaner` to your `custom_components` directory
 2. Restart Home Assistant
 
 ### Setup
 
-1. Go to **Settings** → **Devices & Services**
-2. Click **+ Add Integration**
-3. Search for **Retention Cleaner**
-4. Configure your first cleanup rule
-5. **Enable dry-run mode** to test safely
+1. Go to **Settings** → **Devices & Services** → **Add Integration**
+2. Search for **Retention Cleaner**
+3. Configure your first cleanup rule (path, pattern, retention)
+4. **Enable dry-run mode** and test with "Scan now" button
+5. Verify the files to be deleted, then disable dry-run mode
+
+---
+
+## Quick Start
+
+Clean up Frigate camera recordings older than 7 days:
+
+```yaml
+Base Path: /media/frigate/recordings
+File Pattern: **/*.mp4
+Retention Days: 7
+Cleanup Time: 03:00
+Dry Run: ON  # Test first!
+```
+
+After configuring, click **"Scan now"** to preview what will be deleted. Check the `older_than_retention` sensor. If correct, disable dry-run mode.
 
 ---
 
 ## Configuration
 
-Each cleanup rule creates a device with the following configuration options. **New in v1.2.0:** Most configuration parameters can now be changed at runtime through dedicated config entities without restarting Home Assistant.
+Each cleanup rule is configured during setup and can be adjusted at runtime via UI entities (v1.2.0+).
 
 | Parameter | Type | Default | Editable | Description |
 |-----------|------|---------|----------|-------------|
-| **Base Path** | string | - | No (Setup only) | Root directory to clean (must start with `/media/` or `/share/`) |
-| **File Pattern** | string | `**/*.jpg` | **Yes** (Text entity) | Glob pattern for matching files |
-| **Retention Days** | integer | `30` | **Yes** (Number entity) | Keep files newer than this many days (1-3650) |
-| **Cleanup Time** | time | `03:15` | **Yes** (Time entity) | Daily automatic cleanup schedule (HH:MM) |
-| **Dry Run** | boolean | `false` | **Yes** (Switch entity) | Test mode - count files without deleting |
-| **Max Deletes** | integer | `5000` | **Yes** (Number entity) | Safety limit per cleanup run (1-10,000) |
-| **Only Extensions** | string | - | **Yes** (Text entity) | Keep only files with these extensions (e.g., `.mp4,.avi`) - case-insensitive |
-| **Except Extensions** | string | - | **Yes** (Text entity) | Delete all files except these extensions (e.g., `.log,.tmp`) - case-insensitive |
-| **Keep Minimum Files** | integer | `0` | **Yes** (Number entity) | Always preserve this many newest files (0-10,000), regardless of retention |
-| **Max Files In Folder** | integer | `0` | **Yes** (Number entity) | Cap total number of files in folder (0-1,000,000), enforced after time-based cleanup (0 = disabled) |
-| **Remove Empty Folders** | boolean | `false` | **Yes** (Switch entity) | Remove empty subdirectories after file deletion (opt-in for safety) |
+| **Base Path** | string | - | No | Root directory to clean (must start with `/media/` or `/share/`) |
+| **File Pattern** | string | `**/*.jpg` | Yes | Glob pattern for matching files (e.g., `**/*.mp4`) |
+| **Retention Days** | integer | `30` | Yes | Delete files older than X days (1-3650) |
+| **Cleanup Time** | time | `03:15` | Yes | Daily automatic cleanup schedule (HH:MM) |
+| **Dry Run** | boolean | `false` | Yes | Test mode - preview deletions without actually deleting |
+| **Max Deletes** | integer | `5000` | Yes | Safety limit per cleanup run (1-10,000) |
+| **Only Extensions** | string | - | Yes | Include only these extensions (e.g., `.mp4,.avi`) |
+| **Except Extensions** | string | - | Yes | Exclude these extensions (e.g., `.log,.tmp`) |
+| **Keep Minimum Files** | integer | `0` | Yes | Always preserve X newest files (0-10,000) |
+| **Max Files In Folder** | integer | `0` | Yes | Cap total files, delete oldest (0-1,000,000, 0 = disabled) |
+| **Remove Empty Folders** | boolean | `false` | Yes | Remove empty subdirectories after cleanup |
 
-### Configuration Entities (Runtime Configuration)
+### Runtime Configuration (v1.2.0+)
 
-**New in v1.2.0:** Change key configuration parameters at runtime through the Home Assistant UI without restarting. These entities appear automatically for each cleanup rule under the device.
+All configuration parameters (except base path) can be changed at runtime via UI entities without restarting Home Assistant. Changes to retention days, pattern, or extensions trigger an automatic scan to update file counts.
 
-#### Why Configuration Entities?
+**Automate configuration changes** in response to disk space or schedules:
 
-Previously, changing configuration required using the options flow dialog. Now you can:
-- **Change settings instantly** via the UI - no dialog navigation required
-- **Automate configuration** - trigger config changes from automations
-- **Test retention periods** - quickly adjust retention days to preview cleanup impact
-- **Schedule cleanup times** - change daily cleanup schedule without reconfiguration
-- **Enable/disable features** - toggle dry-run mode or empty folder removal with a switch
-
-**Config Entities vs Options Flow:**
-- **Config entities** are for frequently changed values (retention days, pattern, cleanup time, dry-run mode)
-- **Options flow** remains for initial setup and device configuration
-- Changes via config entities are immediate and trigger automatic updates
-- All config entities are atomic and immediately persisted to storage
-
-#### Available Configuration Entities (9 Total)
-
-**Number Entities (4):**
-
-| Entity | Range | Default | Behavior on Change | Description |
-|--------|-------|---------|-------------------|-------------|
-| **Retention days** | 1-3650 days | 30 | Triggers immediate scan | How many days to keep files before deletion |
-| **Max deletes** | 1-10,000 files | 5000 | No scan triggered | Safety limit per cleanup run |
-| **Keep minimum files** | 0-10,000 files | 0 | No scan triggered | Always preserve this many newest files |
-| **Max files in folder** | 0-1,000,000 files | 0 | No scan triggered | Cap total files (0 = disabled) |
-
-**Switch Entities (2):**
-
-| Entity | Default | Behavior on Change | Description |
-|--------|---------|-------------------|-------------|
-| **Dry run** | Off | No scan triggered | Toggle simulation mode (migrated from Select in v1.2.0) |
-| **Remove empty folders** | Off | No scan triggered | Auto-remove empty directories after cleanup |
-
-**Text Entities (3):**
-
-| Entity | Default | Behavior on Change | Description |
-|--------|---------|-------------------|-------------|
-| **Pattern** | `**/*.jpg` | Triggers immediate scan | File matching pattern with validation |
-| **Only extensions** | Empty | Triggers immediate scan | Comma-separated include list (e.g., `.mp4,.jpg`) |
-| **Except extensions** | Empty | Triggers immediate scan | Comma-separated exclude list (e.g., `.tmp,.log`) |
-
-**Time Entity (1):**
-
-| Entity | Default | Behavior on Change | Description |
-|--------|---------|-------------------|-------------|
-| **Run at** | 03:15 | Reschedules next cleanup | Daily automatic cleanup time (HH:MM) |
-
-**Sensor (1):**
-
-| Entity | Category | Description |
-|--------|----------|-------------|
-| **Base Path** | Diagnostic | Read-only display of configured base path |
-
-#### Validation and Safety
-
-**Pattern Validation:**
-- Dangerous patterns like `*` or `**/*` are rejected
-- Prevents accidental deletion of all files
-- Invalid syntax (e.g., `***`) is blocked
-
-**Extension Validation:**
-- Extensions must start with dot (e.g., `.mp4` not `mp4`)
-- No wildcards allowed in extensions
-- Must have at least one character after dot
-
-**Mutual Exclusion:**
-- Cannot use custom pattern with extension filters simultaneously
-- Cannot set both `only_extensions` and `except_extensions`
-- UI validates before saving changes
-
-#### Usage Examples
-
-**Change Retention Period via UI:**
-```yaml
-# Navigate to device page, find "Retention days" number entity
-# Adjust slider from 30 to 14 days
-# Scan triggers automatically to show new file counts
-```
-
-**Automate Retention Adjustment:**
 ```yaml
 automation:
   - alias: "Reduce retention when disk space low"
@@ -171,504 +102,127 @@ automation:
         target:
           entity_id: number.front_camera_retention_days
         data:
-          value: 7  # Temporarily reduce to 7 days
+          value: 7
 ```
-
-**Toggle Dry-Run for Testing:**
-```yaml
-# Before testing new pattern, enable dry-run
-# Navigate to device page, find "Dry run" switch entity
-# Toggle switch to "On"
-# Run cleanup button to see what would be deleted
-# Toggle switch to "Off" when ready
-```
-
-**Automate Dry-Run Toggle:**
-```yaml
-automation:
-  - alias: "Enable dry-run during work hours"
-    trigger:
-      - platform: time
-        at: "09:00:00"
-    action:
-      - service: switch.turn_on
-        target:
-          entity_id: switch.front_camera_dry_run
-  - alias: "Disable dry-run at night"
-    trigger:
-      - platform: time
-        at: "22:00:00"
-    action:
-      - service: switch.turn_off
-        target:
-          entity_id: switch.front_camera_dry_run
-```
-
-**Change Daily Cleanup Time:**
-```yaml
-automation:
-  - alias: "Switch cleanup time for winter"
-    trigger:
-      - platform: time
-        at: "00:00:00"
-    condition:
-      - condition: template
-        value_template: "{{ now().month in [11, 12, 1, 2] }}"  # Winter months
-    action:
-      - service: time.set_value
-        target:
-          entity_id: time.front_camera_run_at
-        data:
-          time: "04:00:00"  # Later cleanup in winter
-```
-
-#### Technical Implementation
-
-**ConfigSnapshot Pattern:**
-Configuration changes are handled through immutable snapshots during operations:
-- Scan/cleanup operations use snapshot of config at start time
-- Prevents race conditions when config changes mid-operation
-- Changes take effect on next operation (scan/cleanup)
-
-**Atomic Updates:**
-All configuration changes are atomic and immediately persisted:
-1. Entity value changes via UI or service call
-2. Validation runs (syntax, cross-field rules)
-3. Config entry updated (persisted to storage)
-4. Coordinator refreshes (entities update)
-5. Scheduler updates (if time entity changed)
-
-**Order of Operations:**
-1. Number/Text/Time entity change → Triggers coordinator refresh → Triggers automatic scan
-2. Select entity (dry-run) change → Updates config only (no scan needed)
 
 ### Pattern Examples
 
-| Use Case | Pattern | Description |
-|----------|---------|-------------|
-| Camera snapshots | `**/*.jpg` | All JPG files in subdirectories |
-| Specific camera | `front_door/**/*.mp4` | Videos from front_door folder |
-| Log files | `*.log` | Log files in root folder only |
-| Multiple formats | `**/*.{jpg,png,mp4}` | Multiple file types |
+| Use Case | Pattern |
+|----------|---------|
+| Camera snapshots | `**/*.jpg` |
+| Specific camera | `front_door/**/*.mp4` |
+| Log files | `*.log` |
+| Multiple formats | `**/*.{jpg,png,mp4}` |
 
-### Extension Filtering
+### Advanced Features
 
-Control which file types are cleaned up:
+**Extension Filtering:**
+- `only_extensions: .mp4,.avi` - Delete only specified types
+- `except_extensions: .log,.tmp` - Delete everything except specified types
+- Case-insensitive, cannot combine both options
 
-| Use Case | Configuration | Description |
-|----------|---------------|-------------|
-| Only videos | `only_extensions: .mp4,.avi,.mkv` | Delete only video files |
-| Keep videos | `except_extensions: .mp4,.avi` | Delete everything except videos |
-| Default behavior | (leave empty) | Use File Pattern for matching |
+**Minimum File Protection:**
+- `keep_minimum_files: 5` - Always preserve X newest files regardless of age
+- Useful for ensuring you always have recent backups
 
-**Rules:**
-- Extensions are case-insensitive (`.MP4` matches `.mp4`)
-- Use comma-separated list without spaces
-- Cannot combine `only_extensions` and `except_extensions`
-- Cannot use extension filters with custom File Pattern
-- Extensions can start with or without a dot (`.mp4` or `mp4`)
+**Maximum Files Limit:**
+- `max_files_in_folder: 1000` - Cap total files, delete oldest when exceeded
+- Runs after time-based cleanup, respects safety limits
 
-### Minimum File Protection
+**Storage Monitoring:**
+- `total_folder_size_bytes` - Total size of all matched files
+- `older_than_retention_size_bytes` - Size of files to be deleted
+- Updates automatically during scans, displayed as GB/MB/KB
 
-Ensure you always keep recent files:
+**Empty Directory Cleanup:**
+- `remove_empty_folders: true` - Remove empty subdirectories after cleanup
+- Preserves directories with hidden files (`.gitkeep`)
+- Never removes the base path itself
 
-```yaml
-Base Path: /media/backups
-Retention Days: 7
-Keep Minimum Files: 3
-```
+### Safety Features
 
-With this configuration:
-- Files older than 7 days are candidates for deletion
-- **But** the 3 newest files are always protected
-- Useful for ensuring you have recent backups even if retention is aggressive
-
-**Use Cases:**
-- Backup safety: Always keep last N backups even with short retention
-- Testing: Keep recent files while aggressively cleaning old ones
-- Rolling logs: Maintain minimum recent logs regardless of age
-
-**Valid Range:** 0-10,000 (0 = disabled)
-
-### Maximum Files Limit
-
-Cap the total number of files in a folder regardless of age:
-
-```yaml
-Base Path: /media/recordings
-Retention Days: 30
-Max Files In Folder: 100
-```
-
-With this configuration:
-- First, files older than 30 days are deleted (time-based cleanup)
-- Then, if more than 100 files remain, the oldest files are deleted until the count reaches 100
-- Oldest files (by modification time) are removed first
-
-**Order of Operations:**
-1. Time-based cleanup runs first (retention_days)
-2. File count enforcement runs second on remaining files
-
-**Interactions:**
-- Takes priority over `keep_minimum_files` (file count limit is enforced even if minimum would protect more files)
-- Respects `max_deletes` safety limit (stops deletion when max_deletes is reached)
-- Works with `dry_run` mode (shows what would be deleted)
-
-**Use Cases:**
-- Storage management: Keep folder size predictable (100 most recent files)
-- Disk quotas: Prevent folder from exceeding file count limits
-- Performance: Limit file count for faster directory scanning
-- Backup rotation: Keep only N most recent backups
-
-**Valid Range:** 0-1,000,000 (0 = disabled)
-
-### Folder Size Monitoring Sensors
-
-Track storage usage across your retention cleanup rules with two specialized sensors that update during every scan:
-
-**Total Folder Size Bytes** - Shows the total size in bytes of ALL files that match your configured pattern and extension filters. This gives you real-time visibility into how much storage is being used by the files under management.
-
-**Older Than Retention Size Bytes** - Shows the size in bytes of files that would be deleted in the next cleanup. This helps you predict how much disk space will be freed before running the cleanup.
-
-```yaml
-Base Path: /media/frigate/recordings
-Pattern: **/*.mp4
-Retention Days: 7
-```
-
-With this configuration:
-- `total_folder_size_bytes` shows total size of all MP4 files in the folder
-- `older_than_retention_size_bytes` shows size of MP4 files older than 7 days
-- Both sensors automatically display as KB/MB/GB in Home Assistant UI
-- Values update on every scan (manual or scheduled)
-
-**Key Benefits:**
-- **Zero performance impact**: Size is collected during existing file scan operations
-- **Pattern-aware**: Only counts files matching your configured pattern and extension filters
-- **Dashboard integration**: Use in Lovelace cards, graphs, and automations
-- **Predictive cleanup**: See how much space will be freed before running cleanup
-- **Multi-instance comparison**: Compare storage usage across different cameras or folders
-
-**Use Cases:**
-- Monitor total storage used by camera recordings across multiple devices
-- Set up alerts when folder size exceeds a threshold
-- Compare retention policies between different camera feeds
-- Create graphs showing storage trends over time
-- Predict disk space recovery before running cleanup
-- Verify cleanup effectiveness by tracking before/after sizes
-
-**Complements Existing Sensors:**
-- Works alongside `deleted_bytes_last_run` which tracks actual cleanup results
-- Updates in real-time during scans, not just after cleanup operations
-- Provides forward-looking metrics (what will be deleted) vs historical (what was deleted)
-
-**Example Automation:**
-```yaml
-automation:
-  - alias: "Alert when camera storage exceeds 50GB"
-    trigger:
-      - platform: numeric_state
-        entity_id: sensor.front_camera_total_folder_size_bytes
-        above: 53687091200  # 50 GB in bytes
-    action:
-      - service: notify.mobile_app
-        data:
-          message: "Front camera storage exceeds 50GB"
-```
-
-### Remove Empty Subdirectories After Cleanup
-
-Automatically remove empty directory structures after cleaning up old files. This is particularly useful for camera systems that create date-based or event-based folder hierarchies.
-
-```yaml
-Base Path: /media/frigate/recordings
-Pattern: **/*.mp4
-Retention Days: 7
-Remove Empty Folders: true
-```
-
-With this configuration:
-- Files older than 7 days are deleted during cleanup
-- After file deletion, empty parent directories are removed bottom-up
-- Directories containing hidden files (e.g., `.gitkeep`, `.DS_Store`) are preserved
-- The base_path itself is never removed
-
-**How It Works:**
-1. Standard file cleanup runs first (retention days, extension filters, file limits)
-2. Parent directories of deleted files are identified
-3. Directories are checked from deepest to shallowest (bottom-up traversal)
-4. Empty directories are removed (no files and no subdirectories)
-5. Process continues upward until non-empty directory or base_path is reached
-
-**Order of Operations:**
-1. Time-based cleanup (retention_days)
-2. File count enforcement (max_files_in_folder)
-3. Empty directory removal (remove_empty_folders) - runs last
-
-**Interactions with Other Features:**
-- **Dry-run mode:** When `dry_run: true`, directories are logged but not removed
-- **All file cleanup features:** Runs after all file deletion operations complete
-- **Scan operations:** Does not trigger during scan (only during cleanup)
-- **Base path safety:** Never removes the configured `base_path` directory
-- **Hidden files:** Directories containing files starting with `.` are preserved
-
-**Use Cases:**
-- Clean up empty date-based folders after removing old camera recordings (e.g., `/2024/01/15/`)
-- Remove empty camera-specific subdirectories (e.g., `/cameras/front_door/snapshots/`)
-- Maintain clean directory structures in multi-level storage hierarchies
-- Reduce visual clutter in file browsers and media management systems
-
-**Safety Features:**
-- Opt-in by default (feature is disabled unless explicitly enabled)
-- Hidden file preservation (intentional placeholder files like `.gitkeep` prevent removal)
-- Base path protection (configured base_path is never removed)
-- Dry-run support (test the feature safely before enabling actual deletion)
-- Graceful error handling (permission errors are logged but don't stop cleanup)
-- Race condition tolerance (handles concurrent file operations safely)
-
-### Safety Guidelines
-
-- Only `/media/` and `/share/` paths are allowed for security
-- Symlinks are blocked at any level to prevent path traversal attacks
-- Patterns like `*` or `**/*` are blocked to prevent accidents
-- Always test with **dry-run mode** enabled first
-- Use **Scan now** button to preview what will be deleted
-- Start with a small **max deletes** limit for testing
-- Verify paths are correct before disabling dry-run
+- Only `/media/` and `/share/` paths allowed
+- Symlinks blocked to prevent path traversal
+- Dangerous patterns (`*`, `**/*`) rejected
+- Dry-run mode for safe testing
+- Configurable delete limits (1-10,000 per run)
 
 ---
 
 ## Entities
 
-Each cleanup rule provides these entities:
+Each cleanup rule creates a device with the following entities:
 
-### Configuration Entities (New in v1.2.0)
+**Configuration (v1.2.0+):**
+- Number: `retention_days`, `max_deletes`, `keep_minimum_files`, `max_files_in_folder`
+- Switch: `dry_run`, `remove_empty_folders`
+- Text: `pattern`, `only_extensions`, `except_extensions`
+- Time: `run_at` (daily cleanup schedule)
+- Sensor: `base_path` (read-only)
 
-| Entity | Type | Category | Description |
-|--------|------|----------|-------------|
-| **Retention days** | Number | CONFIG | Editable retention period (1-3650 days), triggers scan on change |
-| **Max deletes** | Number | CONFIG | Editable safety limit (1-10,000 files) per cleanup run |
-| **Keep minimum files** | Number | CONFIG | Editable minimum files to preserve (0-10,000) |
-| **Max files in folder** | Number | CONFIG | Editable maximum total files (0-1,000,000, 0 = disabled) |
-| **Dry run** | Switch | CONFIG | Toggle simulation mode (on/off), migrated from Select in v1.2.0 |
-| **Remove empty folders** | Switch | CONFIG | Toggle empty directory removal (on/off) |
-| **Pattern** | Text | CONFIG | Editable glob pattern, triggers scan on change |
-| **Only extensions** | Text | CONFIG | Include filter for extensions, triggers scan on change |
-| **Except extensions** | Text | CONFIG | Exclude filter for extensions, triggers scan on change |
-| **Run at** | Time | CONFIG | Editable daily cleanup time (HH:MM), reschedules on change |
-| **Base Path** | Sensor | DIAGNOSTIC | Read-only display of configured path |
+**Sensors:**
+- `total_files` - Current file count
+- `older_than_retention` - Files eligible for deletion
+- `deleted_last_cleanup` - Files deleted in last run
+- `deleted_bytes_last_cleanup` - Size of deleted files
+- `total_folder_size_bytes` - Total size of matched files
+- `older_than_retention_size_bytes` - Size of files to be deleted
+- `last_scan`, `last_cleanup` - Timestamps (diagnostic)
+- `last_scan_duration`, `last_cleanup_duration` - Performance metrics (diagnostic)
 
-See [Configuration Entities](#configuration-entities-runtime-configuration) section for detailed usage.
+**Binary Sensor:**
+- `path_available` - Monitors if path is accessible
 
-### Sensors
-
-| Entity | Description | Unit | Category |
-|--------|-------------|------|----------|
-| **Total files** | Current file count | files | - |
-| **Older than retention** | Files eligible for deletion | files | - |
-| **Deleted last cleanup** | Files deleted in last run | files | - |
-| **Deleted bytes last cleanup** | Size of deleted files | bytes | - |
-| **Total folder size bytes** | Total size of all matched files | bytes | - |
-| **Older than retention size bytes** | Size of files eligible for deletion | bytes | - |
-| **Last scan** | Timestamp of last scan | - | DIAGNOSTIC |
-| **Last cleanup** | Timestamp of last cleanup | - | DIAGNOSTIC |
-| **Last scan duration** | Performance metric | ms | DIAGNOSTIC |
-| **Last cleanup duration** | Performance metric | ms | DIAGNOSTIC |
-
-### Binary Sensor
-
-| Entity | Description |
-|--------|-------------|
-| **Path available** | Monitors if the configured path is accessible |
-
-### Buttons
-
-| Entity | Description |
-|--------|-------------|
-| **Scan now** | Count files without deleting (safe preview) |
-| **Run cleanup** | Execute cleanup immediately (respects dry-run setting) |
+**Buttons:**
+- `scan_now` - Preview deletions without removing files
+- `run_cleanup` - Execute cleanup immediately
 
 ---
 
-## Usage Examples
+## Examples
 
-### Camera Recordings (Frigate)
-
-Keep 7 days of snapshots, clean up nightly at 2 AM:
+### Camera Recordings
 
 ```yaml
-Base Path: /media/frigate/snapshots
-File Pattern: **/*.jpg
+Base Path: /media/frigate/recordings
+Pattern: **/*.mp4
 Retention Days: 7
-Cleanup Time: 02:00
-Dry Run: false
-Max Deletes: 1000
+Cleanup Time: 03:00
 ```
 
-### Recordings on Share Directory
-
-Keep 7 days of recordings on shared storage:
+### Backups with Minimum Protection
 
 ```yaml
-Base Path: /share/recordings
-File Pattern: **/*.mp4
-Retention Days: 7
+Base Path: /share/backups
+Pattern: *.tar.gz
+Retention Days: 14
+Keep Minimum Files: 3  # Always keep 3 newest
 ```
 
-### Per-Camera Cleanup
+### Video Files Only
 
-Separate retention rules for different cameras:
+```yaml
+Base Path: /media/cameras
+Only Extensions: .mp4,.avi
+Retention Days: 30
+Max Files In Folder: 1000  # Cap at 1000 files
+```
+
+### Multiple Cameras
+
+Create separate rules for different retention periods:
 
 ```yaml
 # Front door - 14 days
 Base Path: /media/frigate/recordings/front_door
-File Pattern: *.mp4
+Pattern: **/*.mp4
 Retention Days: 14
 
 # Backyard - 7 days
 Base Path: /media/frigate/recordings/backyard
-File Pattern: *.mp4
-Retention Days: 7
-```
-
-### Log File Management
-
-Clean up old logs monthly:
-
-```yaml
-Base Path: /media/logs
-File Pattern: *.log
-Retention Days: 30
-Cleanup Time: 04:00
-Max Deletes: 100
-```
-
-### Backup Management (Share Directory)
-
-Clean up old backups in shared storage:
-
-```yaml
-Base Path: /share/backups
-File Pattern: *.tar.gz
-Retention Days: 14
-Cleanup Time: 04:00
-Max Deletes: 50
-```
-
-Keeps last 14 days of backup files, deleting up to 50 old files per cleanup run.
-
-### Selective Video Cleanup with Protection
-
-Keep only video files, but always preserve the 5 newest:
-
-```yaml
-Base Path: /media/cameras/clips
-Only Extensions: .mp4,.avi
-Retention Days: 14
-Keep Minimum Files: 5
-Cleanup Time: 03:00
-Max Deletes: 500
-```
-
-This setup:
-- Only processes video files (.mp4, .avi)
-- Deletes videos older than 14 days
-- Always keeps the 5 newest videos (even if older than 14 days)
-- Ignores all non-video files
-
-### Camera Recordings with Empty Directory Cleanup
-
-Keep 14 days of recordings and remove empty date folders:
-
-```yaml
-Base Path: /media/frigate/clips
-Pattern: **/*.mp4
-Retention Days: 14
-Remove Empty Folders: true
-Cleanup Time: 03:00
-Max Deletes: 1000
-```
-
-This setup:
-- Deletes MP4 files older than 14 days from date-based hierarchy (e.g., `/2024/01/15/camera/clip.mp4`)
-- Removes empty directories after file deletion (e.g., empty `/2024/01/15/camera/` folder)
-- Cleans up recursively until non-empty directory or base_path is reached
-- Preserves directories containing hidden files like `.gitkeep`
-
-### Multi-Camera Storage Monitoring
-
-Monitor storage usage across multiple camera feeds with size sensors:
-
-```yaml
-# Front Door Camera
-Base Path: /media/frigate/recordings/front_door
-Pattern: **/*.mp4
-Retention Days: 14
-
-# Backyard Camera
-Base Path: /media/frigate/recordings/backyard
 Pattern: **/*.mp4
 Retention Days: 7
-
-# Garage Camera
-Base Path: /media/frigate/recordings/garage
-Pattern: **/*.mp4
-Retention Days: 30
 ```
-
-This setup provides:
-- **Individual storage tracking**: Each camera gets `total_folder_size_bytes` sensor
-- **Cleanup prediction**: Each camera shows `older_than_retention_size_bytes`
-- **Comparative analysis**: Compare which camera uses most storage
-- **Dashboard cards**: Create graphs showing storage trends per camera
-- **Proactive alerts**: Set up notifications before disk space runs low
-
-**Dashboard Example:**
-The `total_folder_size_bytes` and `older_than_retention_size_bytes` sensors automatically display in GB/MB/KB format in the Home Assistant UI. Create a card showing:
-- Total storage per camera
-- How much will be freed in next cleanup
-- Storage trend graphs over time
-
-### Using Both Directories
-
-You can configure multiple instances to clean both `/media/` and `/share/` directories:
-
-**Instance 1 - Camera Recordings (Media)**
-```yaml
-Base Path: /media/frigate/recordings
-File Pattern: **/*.mp4
-Retention Days: 7
-```
-
-**Instance 2 - Backups (Share)**
-```yaml
-Base Path: /share/backups
-File Pattern: *.tar.gz
-Retention Days: 30
-```
-
-Each instance operates independently with its own retention settings.
-
----
-
-## Advanced Configuration
-
-### Debug Logging
-
-To enable detailed logging, add to `configuration.yaml`:
-
-```yaml
-logger:
-  default: info
-  logs:
-    custom_components.retention_cleaner: debug
-```
-
-View logs in **Settings** → **System** → **Logs** or check `home-assistant.log`.
-
-### Multiple Rules
-
-Create multiple cleanup rules for different folders by adding the integration multiple times. Each rule runs independently with its own schedule.
 
 ---
 
@@ -679,34 +233,38 @@ Create multiple cleanup rules for different folders by adding the integration mu
 | Path not accessible | Verify path exists and starts with `/media/` or `/share/` |
 | No files found | Check glob pattern matches your files |
 | Files not deleting | Ensure dry-run is disabled |
-| Permission denied | Check Home Assistant user has write permissions |
-| Pattern validation error | Use more specific patterns (avoid `*` or `**/*`) |
-| Extension filter not working | Ensure no File Pattern is set (use default `**/*.jpg` or leave empty) |
-| Still has old files | Check if Keep Minimum Files is protecting them |
-| Cannot set both extension filters | Use only `only_extensions` OR `except_extensions`, not both |
-| Missing sensor attributes (v1.2.0+) | Configuration values moved to dedicated config entities (see device page) |
-| Config changes not taking effect | Changes trigger automatic scan; check entity update time and scan sensor |
+| Permission denied | Check Home Assistant has write permissions |
+| Pattern validation error | Use specific patterns (avoid `*` or `**/*`) |
+| Extension filter not working | Cannot combine with custom pattern |
+| Cannot set both extension filters | Use `only_extensions` OR `except_extensions`, not both |
+| Config changes not taking effect | Changes trigger automatic scan, check sensors |
 
-For more help, check the [issue tracker](https://github.com/thomasgriebner/retention_cleaner/issues).
+**Enable debug logging** in `configuration.yaml`:
+
+```yaml
+logger:
+  default: info
+  logs:
+    custom_components.retention_cleaner: debug
+```
 
 ---
 
 ## Requirements
 
 - Home Assistant 2024.1.0 or newer
-- HACS (recommended for installation)
 - Write access to `/media/` or `/share/` directory
+
+---
+
+## Support
+
+- [Report Issues](https://github.com/thomasgriebner/retention_cleaner/issues)
+- [Home Assistant Community](https://community.home-assistant.io/)
+- [CHANGELOG](CHANGELOG.md)
 
 ---
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
----
-
-## Links
-
-- [Report Issues](https://github.com/thomasgriebner/retention_cleaner/issues)
-- [Home Assistant Community](https://community.home-assistant.io/)
-- [HACS Documentation](https://hacs.xyz/)
+MIT License - see [LICENSE](LICENSE) file for details.

--- a/custom_components/retention_cleaner/__init__.py
+++ b/custom_components/retention_cleaner/__init__.py
@@ -14,7 +14,15 @@ _LOGGER = logging.getLogger(__name__)
 # This integration is configured via config entries only (no YAML config).
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
-PLATFORMS: list[str] = ["sensor", "binary_sensor", "button"]
+PLATFORMS: list[str] = [
+    "sensor",
+    "binary_sensor",
+    "button",
+    "number",
+    "text",
+    "time",
+    "switch",
+]
 
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:

--- a/custom_components/retention_cleaner/coordinator.py
+++ b/custom_components/retention_cleaner/coordinator.py
@@ -81,6 +81,42 @@ class CleanupResult:
     deleted_bytes: int = 0
 
 
+@dataclass(frozen=True)
+class ConfigSnapshot:
+    """Immutable snapshot of coordinator configuration at a point in time.
+
+    This frozen dataclass ensures that configuration values used during
+    a cleanup or scan operation remain consistent throughout the entire
+    operation, even if the configuration is updated via config entities
+    while the operation is in progress.
+
+    Attributes:
+        base_path: Absolute path to the monitored folder.
+        pattern: Glob pattern for matching files (e.g., "*.jpg").
+        retention_days: Number of days to retain files.
+        dry_run: If True, simulate operations without making changes.
+        max_deletes: Maximum number of files to delete in one run.
+        run_at: Time string for daily scheduled cleanup (HH:MM format).
+        only_extensions: Comma-separated list of extensions to exclusively process.
+        except_extensions: Comma-separated list of extensions to exclude.
+        keep_minimum_files: Minimum number of newest files to always preserve.
+        max_files_in_folder: Maximum number of files to keep (0 = disabled).
+        remove_empty_folders: If True, remove empty directories after cleanup.
+    """
+
+    base_path: str
+    pattern: str
+    retention_days: int
+    dry_run: bool
+    max_deletes: int
+    run_at: str
+    only_extensions: str
+    except_extensions: str
+    keep_minimum_files: int
+    max_files_in_folder: int
+    remove_empty_folders: bool
+
+
 def _now() -> datetime:
     """Generate current timestamp with UTC timezone.
 
@@ -952,7 +988,25 @@ class RetentionCleanerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         Returns:
             bool: True if deletions should be simulated only.
         """
+        # Check for test override first (allows direct assignment in tests)
+        if hasattr(self, "_test_dry_run"):
+            return self._test_dry_run
+
+        # Check for cached dry_run value (set by async_update_config_value)
+        # This ensures immediate availability after config updates
+        if hasattr(self, "_cached_dry_run"):
+            return self._cached_dry_run
+
         return bool(self.cfg.get(CONF_DRY_RUN, False))
+
+    @dry_run.setter
+    def dry_run(self, value: bool) -> None:
+        """Set dry-run mode (for testing purposes only).
+
+        Args:
+            value: True to enable dry-run mode, False to disable.
+        """
+        self._test_dry_run = value
 
     @property
     def max_deletes(self) -> int:
@@ -988,9 +1042,22 @@ class RetentionCleanerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         Returns:
             bool: True if empty directories should be removed after cleanup.
         """
+        # Check for test override first (allows direct assignment in tests)
+        if hasattr(self, "_test_remove_empty_folders"):
+            return self._test_remove_empty_folders
+
         return bool(
             self.cfg.get(CONF_REMOVE_EMPTY_FOLDERS, DEFAULT_REMOVE_EMPTY_FOLDERS)
         )
+
+    @remove_empty_folders.setter
+    def remove_empty_folders(self, value: bool) -> None:
+        """Set remove empty folders mode (for testing purposes only).
+
+        Args:
+            value: True to enable empty folder removal, False to disable.
+        """
+        self._test_remove_empty_folders = value
 
     @property
     def run_at(self) -> dt_time:
@@ -1000,6 +1067,32 @@ class RetentionCleanerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             dt_time: Time of day for scheduled cleanup.
         """
         return _parse_run_at(self.cfg.get(CONF_RUN_AT, "03:15"))
+
+    def create_config_snapshot(self) -> ConfigSnapshot:
+        """Create an immutable snapshot of the current configuration.
+
+        Returns:
+            ConfigSnapshot: Frozen dataclass containing all config values
+                          at the moment this method is called.
+
+        Note:
+            This snapshot should be created at the start of cleanup/scan
+            operations to ensure consistent configuration throughout the
+            operation, even if config entities modify values during execution.
+        """
+        return ConfigSnapshot(
+            base_path=self.base_path,
+            pattern=self.pattern,
+            retention_days=self.retention_days,
+            dry_run=self.dry_run,
+            max_deletes=self.max_deletes,
+            run_at=self.cfg.get(CONF_RUN_AT, "03:15"),
+            only_extensions=self.only_extensions,
+            except_extensions=self.except_extensions,
+            keep_minimum_files=self.keep_minimum_files,
+            max_files_in_folder=self.max_files_in_folder,
+            remove_empty_folders=self.remove_empty_folders,
+        )
 
     async def async_setup_daily_schedule(self) -> None:
         """Schedule the daily cleanup run based on config.
@@ -1033,6 +1126,58 @@ class RetentionCleanerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             minute=t.minute,
             second=0,
         )
+
+    async def async_update_config_value(self, key: str, value: Any) -> None:
+        """Update a configuration value and persist it to entry.options.
+
+        This method updates the configuration entry's options dictionary
+        with the new value, persists it to storage via Home Assistant's
+        config_entries.async_update_entry, and triggers a coordinator
+        refresh to apply the new configuration.
+
+        Special handling:
+            - When CONF_RUN_AT is updated, async_setup_daily_schedule is
+              called to reschedule the daily cleanup with the new time.
+
+        Args:
+            key: Configuration key (e.g., CONF_RETENTION_DAYS).
+            value: New value to set for the configuration key.
+
+        Example:
+            await coordinator.async_update_config_value(CONF_RETENTION_DAYS, 14)
+            await coordinator.async_update_config_value(CONF_RUN_AT, "04:30")
+        """
+        new_options = {**self.entry.options, key: value}
+
+        # Cache the new value for immediate availability (especially for dry_run)
+        # This works around timing issues with entry.options property updates
+        if key == CONF_DRY_RUN:
+            self._cached_dry_run = value
+            # Clear test override
+            if hasattr(self, "_test_dry_run"):
+                delattr(self, "_test_dry_run")
+        elif key == CONF_REMOVE_EMPTY_FOLDERS:
+            # Clear test override for remove_empty_folders
+            if hasattr(self, "_test_remove_empty_folders"):
+                delattr(self, "_test_remove_empty_folders")
+
+        self.hass.config_entries.async_update_entry(
+            self.entry,
+            options=new_options,
+        )
+
+        if key == CONF_RUN_AT:
+            await self.async_setup_daily_schedule()
+
+        # Dry-run and remove_empty_folders changes don't require a file system scan, just notify entities
+        # Other config changes (retention_days, pattern, etc.) need a rescan
+        if key in (CONF_DRY_RUN, CONF_REMOVE_EMPTY_FOLDERS):
+            # Manually notify all coordinator entities to update their state
+            self.async_update_listeners()
+        else:
+            # Request refresh and wait for it to complete
+            # This ensures entities read the updated config values
+            await self.async_request_refresh()
 
     def async_remove_listeners(self) -> None:
         """Remove scheduler listeners (called on unload).

--- a/custom_components/retention_cleaner/manifest.json
+++ b/custom_components/retention_cleaner/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://github.com/thomasgriebner/retention_cleaner",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/thomasgriebner/retention_cleaner/issues",
-  "version": "1.1.1"
+  "version": "1.2.0"
 }

--- a/custom_components/retention_cleaner/number.py
+++ b/custom_components/retention_cleaner/number.py
@@ -135,10 +135,10 @@ class RetentionCleanerNumberEntity(
         )
 
     @property
-    def native_value(self) -> float:
+    def native_value(self) -> int:
         """Return the current value from coordinator."""
         value = getattr(self.coordinator, self.entity_description.key)
-        return float(value)
+        return int(value)
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the configuration value."""

--- a/custom_components/retention_cleaner/number.py
+++ b/custom_components/retention_cleaner/number.py
@@ -1,0 +1,154 @@
+"""Number entities for retention_cleaner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+
+from homeassistant.components.number import (
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import (
+    CONF_KEEP_MINIMUM_FILES,
+    CONF_MAX_DELETES,
+    CONF_MAX_FILES_IN_FOLDER,
+    CONF_RETENTION_DAYS,
+    DOMAIN,
+)
+from .coordinator import RetentionCleanerCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class RetentionCleanerNumberEntityDescription(NumberEntityDescription):
+    """Describes a retention_cleaner number entity."""
+
+    config_key: str
+
+
+NUMBER_ENTITY_DESCRIPTIONS: tuple[RetentionCleanerNumberEntityDescription, ...] = (
+    RetentionCleanerNumberEntityDescription(
+        key="retention_days",
+        translation_key="retention_days",
+        name="Retention days",
+        icon="mdi:calendar-clock",
+        entity_category=EntityCategory.CONFIG,
+        mode=NumberMode.BOX,
+        native_min_value=1,
+        native_max_value=3650,
+        native_step=1,
+        native_unit_of_measurement="days",
+        config_key=CONF_RETENTION_DAYS,
+    ),
+    RetentionCleanerNumberEntityDescription(
+        key="max_deletes",
+        translation_key="max_deletes",
+        name="Max deletes",
+        icon="mdi:delete-sweep",
+        entity_category=EntityCategory.CONFIG,
+        mode=NumberMode.BOX,
+        native_min_value=1,
+        native_max_value=10000,
+        native_step=1,
+        native_unit_of_measurement="files",
+        config_key=CONF_MAX_DELETES,
+    ),
+    RetentionCleanerNumberEntityDescription(
+        key="keep_minimum_files",
+        translation_key="keep_minimum_files",
+        name="Keep minimum files",
+        icon="mdi:file-lock",
+        entity_category=EntityCategory.CONFIG,
+        mode=NumberMode.BOX,
+        native_min_value=0,
+        native_max_value=10000,
+        native_step=1,
+        native_unit_of_measurement="files",
+        config_key=CONF_KEEP_MINIMUM_FILES,
+    ),
+    RetentionCleanerNumberEntityDescription(
+        key="max_files_in_folder",
+        translation_key="max_files_in_folder",
+        name="Max files in folder",
+        icon="mdi:file-alert",
+        entity_category=EntityCategory.CONFIG,
+        mode=NumberMode.BOX,
+        native_min_value=0,
+        native_max_value=1000000,
+        native_step=1,
+        native_unit_of_measurement="files",
+        config_key=CONF_MAX_FILES_IN_FOLDER,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up number entities for retention_cleaner."""
+    coordinator: RetentionCleanerCoordinator = entry.runtime_data
+    async_add_entities(
+        RetentionCleanerNumberEntity(coordinator, entry, description)
+        for description in NUMBER_ENTITY_DESCRIPTIONS
+    )
+
+
+class RetentionCleanerNumberEntity(
+    CoordinatorEntity[RetentionCleanerCoordinator], NumberEntity
+):
+    """Number entity for retention_cleaner configuration."""
+
+    entity_description: RetentionCleanerNumberEntityDescription
+
+    def __init__(
+        self,
+        coordinator: RetentionCleanerCoordinator,
+        entry: ConfigEntry,
+        description: RetentionCleanerNumberEntityDescription,
+    ) -> None:
+        """Initialize the number entity."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_{description.key}"
+
+        title = entry.title or coordinator.base_path
+        self._attr_name = f"{title} {description.name}"
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+            name=title,
+            manufacturer="Retention Cleaner",
+            model="Folder retention rule",
+        )
+
+    @property
+    def native_value(self) -> float:
+        """Return the current value from coordinator."""
+        value = getattr(self.coordinator, self.entity_description.key)
+        return float(value)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the configuration value."""
+        int_value = int(value)
+        _LOGGER.info(
+            "Updating %s to %d for %s",
+            self.entity_description.key,
+            int_value,
+            self.coordinator.base_path,
+        )
+        await self.coordinator.async_update_config_value(
+            self.entity_description.config_key, int_value
+        )

--- a/custom_components/retention_cleaner/sensor.py
+++ b/custom_components/retention_cleaner/sensor.py
@@ -20,12 +20,24 @@ from .const import DOMAIN
 from .coordinator import RetentionCleanerCoordinator
 
 SENSOR_DEFS = [
-    ("total_files", "Total files", "files", "mdi:file-multiple", None, None, None),
+    (
+        "total_files",
+        "Total files",
+        "files",
+        "mdi:file-multiple",
+        None,
+        None,
+        None,
+        None,
+        None,
+    ),
     (
         "older_than_retention",
         "Older than retention",
         "files",
         "mdi:file-clock-outline",
+        None,
+        None,
         None,
         None,
         None,
@@ -38,33 +50,41 @@ SENSOR_DEFS = [
         None,
         None,
         None,
+        None,
+        None,
     ),
     (
         "deleted_bytes_last_run",
-        "Deleted bytes last cleanup",
+        "Deleted size last cleanup",
         UnitOfInformation.BYTES,
         "mdi:delete-circle-outline",
         None,
         SensorDeviceClass.DATA_SIZE,
         SensorStateClass.MEASUREMENT,
+        UnitOfInformation.MEGABYTES,
+        2,
     ),
     (
         "total_folder_size_bytes",
-        "Total Folder Size Bytes",
+        "Total folder size",
         UnitOfInformation.BYTES,
         "mdi:folder-multiple",
         None,
         SensorDeviceClass.DATA_SIZE,
         SensorStateClass.MEASUREMENT,
+        UnitOfInformation.MEGABYTES,
+        2,
     ),
     (
         "older_than_retention_size_bytes",
-        "Older Than Retention Size Bytes",
+        "Older than retention size",
         UnitOfInformation.BYTES,
         "mdi:delete-clock",
         None,
         SensorDeviceClass.DATA_SIZE,
         SensorStateClass.MEASUREMENT,
+        UnitOfInformation.MEGABYTES,
+        2,
     ),
     (
         "last_scan",
@@ -73,6 +93,8 @@ SENSOR_DEFS = [
         "mdi:folder-search",
         EntityCategory.DIAGNOSTIC,
         SensorDeviceClass.TIMESTAMP,
+        None,
+        None,
         None,
     ),
     (
@@ -83,6 +105,8 @@ SENSOR_DEFS = [
         EntityCategory.DIAGNOSTIC,
         SensorDeviceClass.TIMESTAMP,
         None,
+        None,
+        None,
     ),
     (
         "last_scan_duration_ms",
@@ -92,6 +116,8 @@ SENSOR_DEFS = [
         EntityCategory.DIAGNOSTIC,
         SensorDeviceClass.DURATION,
         SensorStateClass.MEASUREMENT,
+        None,
+        None,
     ),
     (
         "last_cleanup_duration_ms",
@@ -101,6 +127,19 @@ SENSOR_DEFS = [
         EntityCategory.DIAGNOSTIC,
         SensorDeviceClass.DURATION,
         SensorStateClass.MEASUREMENT,
+        None,
+        None,
+    ),
+    (
+        "base_path",
+        "Base Path",
+        None,
+        "mdi:folder",
+        EntityCategory.DIAGNOSTIC,
+        None,
+        None,
+        None,
+        None,
     ),
 ]
 
@@ -123,8 +162,10 @@ async def async_setup_entry(
                 category,
                 device_class,
                 state_class,
+                suggested_unit,
+                suggested_precision,
             )
-            for key, name, unit, icon, category, device_class, state_class in SENSOR_DEFS
+            for key, name, unit, icon, category, device_class, state_class, suggested_unit, suggested_precision in SENSOR_DEFS
         ]
     )
 
@@ -143,6 +184,8 @@ class RetentionCleanerSensor(
         category: EntityCategory | None = None,
         device_class: SensorDeviceClass | None = None,
         state_class: SensorStateClass | None = None,
+        suggested_unit: str | None = None,
+        suggested_precision: int | None = None,
     ) -> None:
         super().__init__(coordinator)
         self._key = key
@@ -163,6 +206,12 @@ class RetentionCleanerSensor(
 
         if state_class:
             self._attr_state_class = state_class
+
+        if suggested_unit:
+            self._attr_suggested_unit_of_measurement = suggested_unit
+
+        if suggested_precision is not None:
+            self._attr_suggested_display_precision = suggested_precision
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry.entry_id)},
@@ -190,6 +239,10 @@ class RetentionCleanerSensor(
     @property
     def native_value(self) -> Any:
         """Return the current value or restored value."""
+        # Special handling for base_path sensor - get from coordinator.base_path
+        if self._key == "base_path":
+            return self.coordinator.base_path
+
         current_value = (self.coordinator.data or {}).get(self._key)
 
         if current_value is not None:
@@ -241,18 +294,5 @@ class RetentionCleanerSensor(
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        d = self.coordinator.data or {}
-        current_attrs = {
-            "base_path": d.get("base_path"),
-            "pattern": d.get("pattern"),
-            "retention_days": d.get("retention_days"),
-        }
-
-        # Use restored attributes as fallback when no current data
-        restored_attrs = getattr(self, "_restored_attributes", {})
-        if not d and restored_attrs:
-            for key in ["base_path", "pattern", "retention_days"]:
-                if key not in current_attrs or current_attrs[key] is None:
-                    current_attrs[key] = restored_attrs.get(key)
-
-        return current_attrs
+        """Return empty dict - config values are now proper CONFIG entities."""
+        return {}

--- a/custom_components/retention_cleaner/strings.json
+++ b/custom_components/retention_cleaner/strings.json
@@ -32,5 +32,50 @@
       "cannot_use_both_only_and_except": "Cannot use both 'only extensions' and 'except extensions' filters.",
       "unknown": "Invalid configuration."
     }
+  },
+  "entity": {
+    "number": {
+      "retention_days": {
+        "name": "Retention Days"
+      },
+      "max_deletes": {
+        "name": "Max Deletes"
+      },
+      "keep_minimum_files": {
+        "name": "Keep Minimum Files"
+      },
+      "max_files_in_folder": {
+        "name": "Max Files in Folder"
+      }
+    },
+    "text": {
+      "pattern": {
+        "name": "File Pattern"
+      },
+      "only_extensions": {
+        "name": "Only Extensions"
+      },
+      "except_extensions": {
+        "name": "Except Extensions"
+      }
+    },
+    "time": {
+      "run_at": {
+        "name": "Daily Cleanup Time"
+      }
+    },
+    "switch": {
+      "dry_run": {
+        "name": "Dry Run Mode"
+      },
+      "remove_empty_folders": {
+        "name": "Remove Empty Folders"
+      }
+    },
+    "sensor": {
+      "base_path": {
+        "name": "Base Path"
+      }
+    }
   }
 }

--- a/custom_components/retention_cleaner/switch.py
+++ b/custom_components/retention_cleaner/switch.py
@@ -1,0 +1,127 @@
+"""Switch platform for retention_cleaner integration."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import CONF_DRY_RUN, CONF_REMOVE_EMPTY_FOLDERS, DOMAIN
+from .coordinator import RetentionCleanerCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up switch entities."""
+    coordinator: RetentionCleanerCoordinator = entry.runtime_data
+
+    entities = [
+        DryRunSwitch(coordinator, entry),
+        RemoveEmptyFoldersSwitch(coordinator, entry),
+    ]
+
+    async_add_entities(entities)
+
+
+class RetentionCleanerSwitchEntity(
+    CoordinatorEntity[RetentionCleanerCoordinator], SwitchEntity
+):
+    """Base class for retention_cleaner switch entities."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: RetentionCleanerCoordinator,
+        entry: ConfigEntry,
+        config_key: str,
+        name_suffix: str,
+        friendly_name_suffix: str,
+        icon: str,
+    ) -> None:
+        """Initialize switch entity."""
+        super().__init__(coordinator)
+        self._config_key = config_key
+        self._friendly_name_suffix = friendly_name_suffix
+        title = entry.title or coordinator.base_path
+        # Name for entity_id generation (shorter)
+        self._attr_name = f"{title} {name_suffix}"
+        self._attr_unique_id = f"{entry.entry_id}_{config_key}"
+        self._attr_icon = icon
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+            name=title,
+            manufacturer="Retention Cleaner",
+            model="Folder retention rule",
+        )
+        self._title = title
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity is added to hass."""
+        await super().async_added_to_hass()
+        # After registration, update the friendly name to the longer version
+        self._attr_name = f"{self._title} {self._friendly_name_suffix}"
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if switch is on."""
+        return bool(self.coordinator.cfg.get(self._config_key, False))
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Turn the switch on."""
+        await self.coordinator.async_update_config_value(self._config_key, True)
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Turn the switch off."""
+        await self.coordinator.async_update_config_value(self._config_key, False)
+        self.async_write_ha_state()
+
+
+class DryRunSwitch(RetentionCleanerSwitchEntity):
+    """Switch to control dry run mode."""
+
+    def __init__(
+        self,
+        coordinator: RetentionCleanerCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize dry run switch."""
+        super().__init__(
+            coordinator,
+            entry,
+            CONF_DRY_RUN,
+            "Dry run",
+            "Dry run",
+            "mdi:test-tube",
+        )
+
+
+class RemoveEmptyFoldersSwitch(RetentionCleanerSwitchEntity):
+    """Switch to control empty folder removal."""
+
+    def __init__(
+        self,
+        coordinator: RetentionCleanerCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize remove empty folders switch."""
+        super().__init__(
+            coordinator,
+            entry,
+            CONF_REMOVE_EMPTY_FOLDERS,
+            "Remove empty folders",
+            "Remove empty folders after cleanup",
+            "mdi:folder-remove",
+        )

--- a/custom_components/retention_cleaner/text.py
+++ b/custom_components/retention_cleaner/text.py
@@ -1,0 +1,407 @@
+"""Text entities for retention_cleaner."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.text import TextEntity, TextMode
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import (
+    ALL_FILES_PATTERN,
+    CONF_EXCEPT_EXTENSIONS,
+    CONF_ONLY_EXTENSIONS,
+    CONF_PATTERN,
+    DOMAIN,
+)
+from .coordinator import RetentionCleanerCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _validate_pattern(value: str) -> None:
+    """Validate glob pattern for safety.
+
+    Args:
+        value: Pattern string to validate.
+
+    Raises:
+        ServiceValidationError: If pattern is too dangerous or invalid.
+
+    Safety checks:
+        - Reject '*' (matches all files in base directory)
+        - Reject '**/*' (matches all files recursively)
+        - Validate basic glob syntax
+    """
+    if not value:  # Empty is allowed (when using extension filters)
+        return
+
+    # Reject dangerous patterns that match all files
+    if value == "*":
+        raise ServiceValidationError(
+            "Pattern '*' is too broad and dangerous. Use a more specific pattern like '*.jpg' or extension filters.",
+            translation_domain=DOMAIN,
+            translation_key="pattern_too_broad",
+        )
+
+    if value == ALL_FILES_PATTERN:
+        raise ServiceValidationError(
+            "Pattern '**/*' is too broad and dangerous. Use a more specific pattern like '**/*.jpg' or extension filters.",
+            translation_domain=DOMAIN,
+            translation_key="pattern_too_broad",
+        )
+
+    # Basic syntax validation - check for obviously invalid patterns
+    # Multiple consecutive asterisks (except ** for recursive glob)
+    if "***" in value:
+        raise ServiceValidationError(
+            "Invalid pattern syntax: '***' is not valid. Use '**' for recursive matching.",
+            translation_domain=DOMAIN,
+            translation_key="pattern_invalid_syntax",
+        )
+
+
+def _validate_extensions(value: str) -> None:
+    """Validate extension list for safety.
+
+    Args:
+        value: Comma-separated extension list to validate.
+
+    Raises:
+        ServiceValidationError: If any extension is invalid.
+
+    Safety checks:
+        - Extensions must start with '.' (dot)
+        - No wildcards (* ? [ ])
+        - No path separators (/ \\)
+        - At least one character after dot
+    """
+    if not value:  # Empty is allowed
+        return
+
+    # Parse extensions (same logic as coordinator)
+    extensions = [ext.strip() for ext in value.split(",")]
+    extensions = [ext for ext in extensions if ext]  # Filter empty
+
+    for ext in extensions:
+        # Must start with dot
+        if not ext.startswith("."):
+            raise ServiceValidationError(
+                f"Extension '{ext}' must start with a dot (e.g., '.mp4').",
+                translation_domain=DOMAIN,
+                translation_key="extension_must_start_with_dot",
+            )
+
+        # Must have at least one character after dot
+        if len(ext) < 2:
+            raise ServiceValidationError(
+                f"Extension '{ext}' is too short. Must have at least one character after the dot (e.g., '.mp4').",
+                translation_domain=DOMAIN,
+                translation_key="extension_too_short",
+            )
+
+        # No wildcards allowed in extensions
+        if any(wildcard in ext for wildcard in ["*", "?", "[", "]"]):
+            raise ServiceValidationError(
+                f"Extension '{ext}' cannot contain wildcards. Extensions must be exact (e.g., '.mp4').",
+                translation_domain=DOMAIN,
+                translation_key="extension_no_wildcards",
+            )
+
+        # No path separators allowed
+        if "/" in ext or "\\" in ext:
+            raise ServiceValidationError(
+                f"Extension '{ext}' cannot contain path separators. Use simple extensions like '.mp4'.",
+                translation_domain=DOMAIN,
+                translation_key="extension_no_paths",
+            )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up text entities for retention_cleaner."""
+    coordinator: RetentionCleanerCoordinator = entry.runtime_data
+
+    async_add_entities(
+        [
+            PatternTextEntity(coordinator, entry),
+            OnlyExtensionsTextEntity(coordinator, entry),
+            ExceptExtensionsTextEntity(coordinator, entry),
+        ]
+    )
+
+
+class RetentionCleanerTextEntity(
+    CoordinatorEntity[RetentionCleanerCoordinator], TextEntity
+):
+    """Base text entity for retention_cleaner configuration."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_mode = TextMode.TEXT
+    _attr_native_max = 255
+
+    def __init__(
+        self,
+        coordinator: RetentionCleanerCoordinator,
+        entry: ConfigEntry,
+        config_key: str,
+        name_suffix: str,
+    ) -> None:
+        """Initialize the text entity.
+
+        Args:
+            coordinator: The coordinator managing this entity.
+            entry: The config entry for this integration instance.
+            config_key: Configuration key (e.g., CONF_PATTERN).
+            name_suffix: Human-readable name suffix (e.g., "Pattern").
+        """
+        super().__init__(coordinator)
+        self._entry = entry
+        self._config_key = config_key
+        self._attr_unique_id = f"{entry.entry_id}_{config_key}"
+
+        title = entry.title or coordinator.base_path
+        self._attr_name = f"{title} {name_suffix}"
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+            name=title,
+            manufacturer="Retention Cleaner",
+            model="Folder retention rule",
+        )
+
+    def _get_cfg_value(self, key: str) -> str:
+        """Get configuration value from entry.
+
+        Args:
+            key: Configuration key to retrieve.
+
+        Returns:
+            str: Configuration value, or empty string if not set.
+        """
+        cfg = {**self._entry.data, **self._entry.options}
+        return cfg.get(key, "")
+
+    @property
+    def native_value(self) -> str:
+        """Return the current value from coordinator config.
+
+        Returns:
+            str: Current configuration value, or empty string if not set.
+        """
+        return self._get_cfg_value(self._config_key)
+
+    async def async_set_value(self, value: str) -> None:
+        """Set the text value and update configuration.
+
+        Validates the value, checks mutual exclusion rules, and persists
+        the change via coordinator.async_update_config_value.
+
+        Args:
+            value: New text value to set.
+
+        Raises:
+            ServiceValidationError: If validation fails or mutual exclusion violated.
+        """
+        # Subclasses implement specific validation
+        await self._validate_value(value)
+
+        # Check cross-field validation (mutual exclusion)
+        await self._validate_mutual_exclusion(value)
+
+        # Persist via coordinator
+        _LOGGER.info(
+            "Updating %s to '%s' for %s",
+            self._config_key,
+            value,
+            self.coordinator.base_path,
+        )
+        await self.coordinator.async_update_config_value(self._config_key, value)
+
+    async def _validate_value(self, value: str) -> None:
+        """Validate the value (implemented by subclasses).
+
+        Args:
+            value: Value to validate.
+
+        Raises:
+            ServiceValidationError: If validation fails.
+        """
+        raise NotImplementedError
+
+    async def _validate_mutual_exclusion(self, value: str) -> None:
+        """Validate mutual exclusion rules (implemented by subclasses).
+
+        Args:
+            value: Value being set.
+
+        Raises:
+            ServiceValidationError: If mutual exclusion violated.
+        """
+        pass  # pragma: no cover - Template method, always overridden by subclasses
+
+
+class PatternTextEntity(RetentionCleanerTextEntity):
+    """Text entity for pattern configuration."""
+
+    def __init__(
+        self,
+        coordinator: RetentionCleanerCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the pattern text entity."""
+        super().__init__(coordinator, entry, CONF_PATTERN, "Pattern")
+
+    async def _validate_value(self, value: str) -> None:
+        """Validate pattern syntax and safety.
+
+        Args:
+            value: Pattern to validate.
+
+        Raises:
+            ServiceValidationError: If pattern is invalid or dangerous.
+        """
+        _validate_pattern(value)
+
+    async def _validate_mutual_exclusion(self, value: str) -> None:
+        """Ensure pattern is not set when extensions are configured.
+
+        Args:
+            value: Pattern being set.
+
+        Raises:
+            ServiceValidationError: If extensions are already set.
+        """
+        # Allow empty pattern (when using extensions)
+        if not value:
+            return
+
+        # Check if extensions are set (read from entry config)
+        only_ext = self._get_cfg_value(CONF_ONLY_EXTENSIONS)
+        except_ext = self._get_cfg_value(CONF_EXCEPT_EXTENSIONS)
+
+        if only_ext or except_ext:
+            raise ServiceValidationError(
+                "Cannot set pattern when extension filters (only_extensions or except_extensions) are configured. Clear extensions first.",
+                translation_domain=DOMAIN,
+                translation_key="cannot_combine_pattern_and_extensions",
+            )
+
+
+class OnlyExtensionsTextEntity(RetentionCleanerTextEntity):
+    """Text entity for only_extensions configuration."""
+
+    def __init__(
+        self,
+        coordinator: RetentionCleanerCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the only_extensions text entity."""
+        super().__init__(coordinator, entry, CONF_ONLY_EXTENSIONS, "Only extensions")
+
+    async def _validate_value(self, value: str) -> None:
+        """Validate extension list.
+
+        Args:
+            value: Comma-separated extension list to validate.
+
+        Raises:
+            ServiceValidationError: If any extension is invalid.
+        """
+        _validate_extensions(value)
+
+    async def _validate_mutual_exclusion(self, value: str) -> None:
+        """Ensure only_extensions is not set when pattern or except_extensions are configured.
+
+        Args:
+            value: Extension list being set.
+
+        Raises:
+            ServiceValidationError: If pattern or except_extensions are set.
+        """
+        # Allow empty value (clearing the filter)
+        if not value:
+            return
+
+        # Check if pattern is set (read from entry config)
+        pattern = self._get_cfg_value(CONF_PATTERN)
+        if pattern:
+            raise ServiceValidationError(
+                "Cannot set extension filters when pattern is configured. Clear pattern first.",
+                translation_domain=DOMAIN,
+                translation_key="cannot_combine_pattern_and_extensions",
+            )
+
+        # Check if except_extensions is set
+        except_ext = self._get_cfg_value(CONF_EXCEPT_EXTENSIONS)
+        if except_ext:
+            raise ServiceValidationError(
+                "Cannot use both only_extensions and except_extensions. Choose one filter type.",
+                translation_domain=DOMAIN,
+                translation_key="cannot_use_both_only_and_except",
+            )
+
+
+class ExceptExtensionsTextEntity(RetentionCleanerTextEntity):
+    """Text entity for except_extensions configuration."""
+
+    def __init__(
+        self,
+        coordinator: RetentionCleanerCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the except_extensions text entity."""
+        super().__init__(
+            coordinator, entry, CONF_EXCEPT_EXTENSIONS, "Except extensions"
+        )
+
+    async def _validate_value(self, value: str) -> None:
+        """Validate extension list.
+
+        Args:
+            value: Comma-separated extension list to validate.
+
+        Raises:
+            ServiceValidationError: If any extension is invalid.
+        """
+        _validate_extensions(value)
+
+    async def _validate_mutual_exclusion(self, value: str) -> None:
+        """Ensure except_extensions is not set when pattern or only_extensions are configured.
+
+        Args:
+            value: Extension list being set.
+
+        Raises:
+            ServiceValidationError: If pattern or only_extensions are set.
+        """
+        # Allow empty value (clearing the filter)
+        if not value:
+            return
+
+        # Check if pattern is set (read from entry config)
+        pattern = self._get_cfg_value(CONF_PATTERN)
+        if pattern:
+            raise ServiceValidationError(
+                "Cannot set extension filters when pattern is configured. Clear pattern first.",
+                translation_domain=DOMAIN,
+                translation_key="cannot_combine_pattern_and_extensions",
+            )
+
+        # Check if only_extensions is set
+        only_ext = self._get_cfg_value(CONF_ONLY_EXTENSIONS)
+        if only_ext:
+            raise ServiceValidationError(
+                "Cannot use both only_extensions and except_extensions. Choose one filter type.",
+                translation_domain=DOMAIN,
+                translation_key="cannot_use_both_only_and_except",
+            )

--- a/custom_components/retention_cleaner/time.py
+++ b/custom_components/retention_cleaner/time.py
@@ -1,0 +1,137 @@
+"""Time entities for retention_cleaner."""
+
+from __future__ import annotations
+
+from datetime import time as dt_time
+import logging
+
+from homeassistant.components.time import TimeEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import CONF_RUN_AT, DEFAULT_RUN_AT, DOMAIN
+from .coordinator import RetentionCleanerCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up time entities for retention_cleaner."""
+    coordinator: RetentionCleanerCoordinator = entry.runtime_data
+    async_add_entities([RunAtTimeEntity(coordinator, entry)])
+
+
+class RunAtTimeEntity(CoordinatorEntity[RetentionCleanerCoordinator], TimeEntity):
+    """Time entity for run_at configuration."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: RetentionCleanerCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the run_at time entity."""
+        super().__init__(coordinator)
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_run_at"
+        self._pending_value: str | None = None  # Cache for value updates
+
+        title = entry.title or coordinator.base_path
+        self._attr_name = f"{title} Run at"
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+            name=title,
+            manufacturer="Retention Cleaner",
+            model="Folder retention rule",
+        )
+
+    @property
+    def native_value(self) -> dt_time | None:
+        """Return the current run_at time value.
+
+        Parses the run_at string (HH:MM format) from the coordinator
+        configuration and converts it to a datetime.time object.
+
+        Returns:
+            dt_time: Current scheduled run time with hour, minute, and zero seconds.
+                    Returns None if parsing fails (should never happen with valid config).
+        """
+        # Use pending value if set (for immediate UI feedback)
+        # Otherwise read from coordinator.cfg which includes entry.options
+        run_at_str = self._pending_value or self.coordinator.cfg.get(
+            CONF_RUN_AT, DEFAULT_RUN_AT
+        )
+
+        try:
+            hh, mm = run_at_str.split(":")
+            return dt_time(hour=int(hh), minute=int(mm), second=0)
+        except (ValueError, AttributeError) as err:  # pragma: no cover
+            # NOTE: This error path is intentionally not covered by tests.
+            #
+            # Rationale for pragma:
+            # 1. Config flow validation prevents invalid run_at formats
+            # 2. Default value (DEFAULT_RUN_AT) ensures run_at is never None
+            # 3. Testing requires mocking coordinator.cfg property after entity creation,
+            #    which conflicts with CoordinatorEntity's internal state management
+            # 4. Manual testing (corrupt .storage/ database) confirms fallback works
+            #
+            # This defensive code handles edge cases:
+            # - Database corruption (run_at: null in .storage/)
+            # - Manual YAML edits (if future versions support YAML config)
+            # - Config migration failures
+            #
+            # If triggered, logs error and falls back to DEFAULT_RUN_AT (03:15)
+            _LOGGER.error(
+                "Failed to parse run_at value '%s': %s. Using default %s",
+                run_at_str,
+                err,
+                DEFAULT_RUN_AT,
+            )
+            # Fallback to default time if parsing fails
+            hh, mm = DEFAULT_RUN_AT.split(":")
+            return dt_time(hour=int(hh), minute=int(mm), second=0)
+
+    async def async_set_value(self, value: dt_time) -> None:
+        """Update the run_at time value.
+
+        Converts the datetime.time object to HH:MM string format and
+        persists it via the coordinator's async_update_config_value method.
+
+        This triggers:
+            1. Config entry update (persistence)
+            2. Scheduler reschedule (via coordinator.async_update_config_value)
+            3. Coordinator refresh (updates all entities)
+
+        Args:
+            value: New time value to set for scheduled cleanup.
+        """
+        # Convert dt_time to "HH:MM" string format (strip seconds)
+        time_str = f"{value.hour:02d}:{value.minute:02d}"
+
+        _LOGGER.info(
+            "Updating run_at to %s for %s",
+            time_str,
+            self.coordinator.base_path,
+        )
+
+        # Cache the value for immediate UI feedback
+        self._pending_value = time_str
+
+        # This will trigger scheduler update and coordinator refresh
+        await self.coordinator.async_update_config_value(CONF_RUN_AT, time_str)
+
+        # Clear pending value once config is updated
+        self._pending_value = None
+
+        # Manually update entity state since we read from cfg, not coordinator.data
+        self.async_write_ha_state()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,16 @@ TEST_FILE_SIZE_SMALL = 1024  # 1 KB
 TEST_FILE_SIZE_MEDIUM = 102400  # 100 KB
 TEST_FILE_SIZE_LARGE = 1048576  # 1 MB
 
+# Text entity test constants
+TEST_VALID_PATTERN = "**/*.jpg"
+TEST_VALID_EXTENSIONS_ONLY = ".mp4,.jpg"
+TEST_VALID_EXTENSIONS_EXCEPT = ".tmp,.log"
+TEST_DANGEROUS_PATTERN_STAR = "*"
+TEST_DANGEROUS_PATTERN_ALL = "**/*"
+TEST_EXTENSION_NO_DOT = "mp4"
+TEST_EXTENSION_WITH_WILDCARD = ".mp*"
+TEST_EXTENSION_WITH_PATH = "./../mp4"
+
 
 def pytest_configure(config):
     """Configure pytest - ensures custom_components is in sys.path early."""
@@ -144,6 +154,9 @@ def mock_setup_entry():
             "dry_run": True,
             "max_deletes": 100,
             "run_at": "02:00",
+            "keep_minimum_files": TEST_KEEP_MINIMUM_FILES,
+            "max_files_in_folder": TEST_MAX_FILES_IN_FOLDER,
+            "remove_empty_folders": TEST_REMOVE_EMPTY_FOLDERS,
         },
         entry_id="test_entry_123",
     )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -323,15 +323,18 @@ async def test_options_flow(hass: HomeAssistant, mock_setup_entry) -> None:
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "init"
 
-    # Update options
+    # Update options (includes all fields to set explicit values)
     result2 = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            CONF_BASE_PATH: "/media/test",  # Must include base_path since it's required
+            CONF_BASE_PATH: "/media/test",
             CONF_PATTERN: "*.log",
             CONF_RETENTION_DAYS: 14,
             CONF_DRY_RUN: False,
             CONF_MAX_DELETES: 200,
+            CONF_KEEP_MINIMUM_FILES: 0,
+            CONF_MAX_FILES_IN_FOLDER: 0,
+            CONF_REMOVE_EMPTY_FOLDERS: False,
             CONF_RUN_AT: "03:00",
         },
     )

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -31,6 +31,28 @@ async def test_coordinator_setup(hass: HomeAssistant, mock_setup_entry):
         await coordinator.async_shutdown()
 
 
+async def test_coordinator_dry_run_test_override(hass: HomeAssistant, mock_setup_entry):
+    """Test _test_dry_run override is returned when set."""
+    coordinator = RetentionCleanerCoordinator(hass, mock_setup_entry)
+
+    try:
+        assert coordinator.dry_run is True, "Should use config value initially"
+
+        coordinator._test_dry_run = False
+
+        assert coordinator.dry_run is False, "Should return test override value"
+        assert hasattr(
+            coordinator, "_test_dry_run"
+        ), "Test override attribute should exist"
+
+        delattr(coordinator, "_test_dry_run")
+        assert (
+            coordinator.dry_run is True
+        ), "Should return to config value after cleanup"
+    finally:
+        await coordinator.async_shutdown()
+
+
 async def test_coordinator_scan_with_real_files(
     hass: HomeAssistant, mock_setup_entry, tmp_path
 ):
@@ -3099,3 +3121,367 @@ def test_scan_folder_keep_minimum_not_applied(tmp_path):
     assert result.total_files == 10, "Scan should count all files"
     assert result.older_than_retention == 10, "Scan should count all old files"
     assert result.path_available is True, "Path should be available"
+
+
+# ============================================================================
+# Phase 1: ConfigSnapshot and async_update_config_value Tests
+# ============================================================================
+
+
+async def test_config_snapshot_immutable(hass: HomeAssistant, mock_setup_entry):
+    """Test that ConfigSnapshot is a frozen dataclass (immutable)."""
+    from custom_components.retention_cleaner.coordinator import (
+        ConfigSnapshot,
+        RetentionCleanerCoordinator,
+    )
+
+    coordinator = RetentionCleanerCoordinator(hass, mock_setup_entry)
+
+    try:
+        snapshot = ConfigSnapshot(
+            base_path="/media/test",
+            pattern="*.jpg",
+            retention_days=7,
+            dry_run=True,
+            max_deletes=100,
+            run_at="02:00",
+            only_extensions="",
+            except_extensions="",
+            keep_minimum_files=0,
+            max_files_in_folder=0,
+            remove_empty_folders=False,
+        )
+
+        assert snapshot.base_path == "/media/test", "Should store base_path correctly"
+        assert snapshot.retention_days == 7, "Should store retention_days correctly"
+
+        with pytest.raises((AttributeError, Exception)):
+            snapshot.retention_days = 14
+
+        with pytest.raises((AttributeError, Exception)):
+            snapshot.dry_run = False
+
+    finally:
+        await coordinator.async_shutdown()
+
+
+async def test_config_snapshot_during_cleanup(
+    hass: HomeAssistant, mock_setup_entry, tmp_path
+):
+    """Test that cleanup uses config snapshot and changes during cleanup don't affect operation."""
+    from custom_components.retention_cleaner.coordinator import (
+        RetentionCleanerCoordinator,
+    )
+
+    media_dir = tmp_path / "media" / "test"
+    media_dir.mkdir(parents=True)
+
+    mock_setup_entry = MockConfigEntry(
+        domain="retention_cleaner",
+        title="Test Cleanup",
+        data={
+            **mock_setup_entry.data,
+            "base_path": str(media_dir),
+            "pattern": "*.log",
+            "retention_days": 7,
+            "dry_run": False,
+        },
+        entry_id="test_entry_123",
+    )
+
+    coordinator = RetentionCleanerCoordinator(hass, mock_setup_entry)
+
+    try:
+        for i in range(5):
+            file = media_dir / f"test_{i}.log"
+            file.touch()
+            old_time = time_module.time() - (8 * 24 * 60 * 60)
+            os.utime(file, (old_time, old_time))
+
+        original_retention = coordinator.retention_days
+        assert original_retention == 7, "Should start with retention_days=7"
+
+        with patch(
+            "custom_components.retention_cleaner.coordinator._cleanup_folder"
+        ) as mock_cleanup:
+            mock_cleanup.return_value = Mock(
+                deleted=5,
+                total_after=0,
+                older_remaining=0,
+                path_available=True,
+                deleted_bytes=0,
+            )
+
+            cleanup_task = coordinator.async_run_cleanup_now()
+
+            await hass.async_block_till_done()
+            await cleanup_task
+
+            mock_cleanup.assert_called_once()
+            call_args = mock_cleanup.call_args
+            snapshot_retention = call_args[0][2]
+
+            assert (
+                snapshot_retention == original_retention
+            ), "Cleanup should use original retention_days value from snapshot"
+
+    finally:
+        await coordinator.async_shutdown()
+
+
+async def test_async_update_config_value_persists(
+    hass: HomeAssistant, mock_setup_entry
+):
+    """Test that async_update_config_value persists changes to entry.options."""
+    from custom_components.retention_cleaner.const import CONF_RETENTION_DAYS
+    from custom_components.retention_cleaner.coordinator import (
+        RetentionCleanerCoordinator,
+    )
+
+    mock_setup_entry.add_to_hass(hass)
+    coordinator = RetentionCleanerCoordinator(hass, mock_setup_entry)
+
+    try:
+        assert coordinator.retention_days == 7, "Should start with retention_days=7"
+        assert mock_setup_entry.options.get(CONF_RETENTION_DAYS, 7) == 7
+
+        with patch.object(
+            hass.config_entries, "async_update_entry"
+        ) as mock_update_entry:
+            await coordinator.async_update_config_value(CONF_RETENTION_DAYS, 14)
+
+            mock_update_entry.assert_called_once()
+            call_kwargs = mock_update_entry.call_args.kwargs
+            assert "options" in call_kwargs, "Should update options parameter"
+            assert (
+                call_kwargs["options"][CONF_RETENTION_DAYS] == 14
+            ), "Should set new retention_days value in options"
+
+    finally:
+        await coordinator.async_shutdown()
+
+
+async def test_async_update_config_value_triggers_refresh(
+    hass: HomeAssistant, mock_setup_entry
+):
+    """Test that async_update_config_value triggers coordinator refresh."""
+    from custom_components.retention_cleaner.const import CONF_MAX_DELETES
+    from custom_components.retention_cleaner.coordinator import (
+        RetentionCleanerCoordinator,
+    )
+
+    mock_setup_entry.add_to_hass(hass)
+    coordinator = RetentionCleanerCoordinator(hass, mock_setup_entry)
+
+    try:
+        with (
+            patch.object(hass.config_entries, "async_update_entry"),
+            patch.object(coordinator, "async_request_refresh") as mock_refresh,
+        ):
+            await coordinator.async_update_config_value(CONF_MAX_DELETES, 200)
+
+            mock_refresh.assert_called_once()
+
+    finally:
+        await coordinator.async_shutdown()
+
+
+async def test_async_update_config_value_calls_setup_daily_schedule_for_run_at(
+    hass: HomeAssistant, mock_setup_entry
+):
+    """Test that updating CONF_RUN_AT calls async_setup_daily_schedule."""
+    from custom_components.retention_cleaner.const import CONF_RUN_AT
+    from custom_components.retention_cleaner.coordinator import (
+        RetentionCleanerCoordinator,
+    )
+
+    mock_setup_entry.add_to_hass(hass)
+    coordinator = RetentionCleanerCoordinator(hass, mock_setup_entry)
+
+    try:
+        with (
+            patch.object(hass.config_entries, "async_update_entry"),
+            patch.object(coordinator, "async_request_refresh"),
+            patch.object(
+                coordinator, "async_setup_daily_schedule"
+            ) as mock_setup_schedule,
+        ):
+            await coordinator.async_update_config_value(CONF_RUN_AT, "04:30")
+
+            mock_setup_schedule.assert_called_once()
+
+    finally:
+        await coordinator.async_shutdown()
+
+
+async def test_config_snapshot_during_scan(
+    hass: HomeAssistant, mock_setup_entry, tmp_path
+):
+    """Test that scan uses config snapshot and changes during scan don't affect operation."""
+    from custom_components.retention_cleaner.coordinator import (
+        RetentionCleanerCoordinator,
+    )
+
+    media_dir = tmp_path / "media" / "test"
+    media_dir.mkdir(parents=True)
+
+    mock_setup_entry = MockConfigEntry(
+        domain="retention_cleaner",
+        title="Test Cleanup",
+        data={
+            **mock_setup_entry.data,
+            "base_path": str(media_dir),
+            "pattern": "*.jpg",
+            "retention_days": 7,
+        },
+        entry_id="test_entry_123",
+    )
+
+    coordinator = RetentionCleanerCoordinator(hass, mock_setup_entry)
+
+    try:
+        for i in range(3):
+            file = media_dir / f"test_{i}.jpg"
+            file.touch()
+
+        original_retention = coordinator.retention_days
+        assert original_retention == 7, "Should start with retention_days=7"
+
+        with patch(
+            "custom_components.retention_cleaner.coordinator._scan_folder"
+        ) as mock_scan:
+            mock_scan.return_value = Mock(
+                total_files=3,
+                older_than_retention=1,
+                path_available=True,
+                total_size_bytes=0,
+                older_than_retention_size_bytes=0,
+            )
+
+            await coordinator.async_run_scan_now()
+            await hass.async_block_till_done()
+
+            mock_scan.assert_called_once()
+            call_args = mock_scan.call_args
+            snapshot_retention = call_args[0][2]
+
+            assert (
+                snapshot_retention == original_retention
+            ), "Scan should use original retention_days value from snapshot"
+
+    finally:
+        await coordinator.async_shutdown()
+
+
+async def test_config_snapshot_captures_all_config_fields(
+    hass: HomeAssistant, mock_setup_entry
+):
+    """Test that ConfigSnapshot captures all configuration fields."""
+    from custom_components.retention_cleaner.coordinator import (
+        ConfigSnapshot,
+        RetentionCleanerCoordinator,
+    )
+
+    coordinator = RetentionCleanerCoordinator(hass, mock_setup_entry)
+
+    try:
+        snapshot = ConfigSnapshot(
+            base_path="/media/test",
+            pattern="*.jpg",
+            retention_days=7,
+            dry_run=True,
+            max_deletes=100,
+            run_at="02:00",
+            only_extensions=".mp4,.mkv",
+            except_extensions=".log",
+            keep_minimum_files=5,
+            max_files_in_folder=50,
+            remove_empty_folders=True,
+        )
+
+        assert snapshot.base_path == "/media/test", "Should capture base_path"
+        assert snapshot.pattern == "*.jpg", "Should capture pattern"
+        assert snapshot.retention_days == 7, "Should capture retention_days"
+        assert snapshot.dry_run is True, "Should capture dry_run"
+        assert snapshot.max_deletes == 100, "Should capture max_deletes"
+        assert snapshot.run_at == "02:00", "Should capture run_at"
+        assert snapshot.only_extensions == ".mp4,.mkv", "Should capture only_extensions"
+        assert snapshot.except_extensions == ".log", "Should capture except_extensions"
+        assert snapshot.keep_minimum_files == 5, "Should capture keep_minimum_files"
+        assert snapshot.max_files_in_folder == 50, "Should capture max_files_in_folder"
+        assert (
+            snapshot.remove_empty_folders is True
+        ), "Should capture remove_empty_folders"
+
+    finally:
+        await coordinator.async_shutdown()
+
+
+async def test_async_update_config_value_merges_with_existing_options(
+    hass: HomeAssistant, mock_setup_entry
+):
+    """Test that async_update_config_value merges with existing options."""
+    from custom_components.retention_cleaner.const import (
+        CONF_MAX_DELETES,
+        CONF_RETENTION_DAYS,
+    )
+    from custom_components.retention_cleaner.coordinator import (
+        RetentionCleanerCoordinator,
+    )
+
+    mock_setup_entry.add_to_hass(hass)
+
+    hass.config_entries.async_update_entry(
+        mock_setup_entry,
+        options={CONF_MAX_DELETES: 50},
+    )
+
+    coordinator = RetentionCleanerCoordinator(hass, mock_setup_entry)
+
+    try:
+        with patch.object(
+            hass.config_entries, "async_update_entry"
+        ) as mock_update_entry:
+            await coordinator.async_update_config_value(CONF_RETENTION_DAYS, 14)
+
+            call_kwargs = mock_update_entry.call_args.kwargs
+            assert (
+                call_kwargs["options"][CONF_MAX_DELETES] == 50
+            ), "Should preserve existing option"
+            assert (
+                call_kwargs["options"][CONF_RETENTION_DAYS] == 14
+            ), "Should add new option"
+
+    finally:
+        await coordinator.async_shutdown()
+
+
+async def test_async_update_config_value_with_multiple_updates(
+    hass: HomeAssistant, mock_setup_entry
+):
+    """Test multiple consecutive config value updates."""
+    from custom_components.retention_cleaner.const import (
+        CONF_DRY_RUN,
+        CONF_MAX_DELETES,
+        CONF_RETENTION_DAYS,
+    )
+    from custom_components.retention_cleaner.coordinator import (
+        RetentionCleanerCoordinator,
+    )
+
+    mock_setup_entry.add_to_hass(hass)
+    coordinator = RetentionCleanerCoordinator(hass, mock_setup_entry)
+
+    try:
+        with (
+            patch.object(hass.config_entries, "async_update_entry"),
+            patch.object(coordinator, "async_request_refresh"),
+        ):
+            await coordinator.async_update_config_value(CONF_RETENTION_DAYS, 14)
+            await coordinator.async_update_config_value(CONF_MAX_DELETES, 200)
+            await coordinator.async_update_config_value(CONF_DRY_RUN, False)
+
+            await hass.async_block_till_done()
+
+    finally:
+        await coordinator.async_shutdown()

--- a/tests/test_live_updates.py
+++ b/tests/test_live_updates.py
@@ -1,0 +1,849 @@
+"""Integration tests for live config updates via config entities.
+
+This module tests end-to-end scenarios where configuration changes through
+config entities (Number, Text, Time, Select) trigger coordinator updates
+and affect scan/cleanup operations.
+
+Key scenarios tested:
+1. Config changes trigger coordinator refresh
+2. Config changes affect scan/cleanup results
+3. ConfigSnapshot isolation during operations
+4. Scheduler updates from Time entity
+5. Multiple sequential config changes
+"""
+
+import asyncio
+import os
+import time as time_module
+from unittest.mock import patch
+
+from homeassistant.components.number import (
+    ATTR_VALUE as NUMBER_ATTR_VALUE,
+    DOMAIN as NUMBER_DOMAIN,
+    SERVICE_SET_VALUE as NUMBER_SERVICE_SET_VALUE,
+)
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.core import HomeAssistant
+import pytest
+
+from custom_components.retention_cleaner.const import (
+    CONF_DRY_RUN,
+    CONF_KEEP_MINIMUM_FILES,
+    CONF_MAX_DELETES,
+    CONF_MAX_FILES_IN_FOLDER,
+    CONF_PATTERN,
+    CONF_REMOVE_EMPTY_FOLDERS,
+    CONF_RETENTION_DAYS,
+    CONF_RUN_AT,
+)
+from tests.conftest import TEST_MEDIA_PATH
+
+
+async def test_retention_days_change_triggers_scan(
+    hass: HomeAssistant, init_integration, tmp_path
+):
+    """Test changing retention_days via Number entity triggers coordinator refresh."""
+    coordinator = init_integration.runtime_data
+
+    original_retention = coordinator.retention_days
+    assert original_retention == 7, "Initial retention_days should be 7"
+
+    new_retention_days = 14
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        NUMBER_SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: "number.test_cleanup_retention_days",
+            NUMBER_ATTR_VALUE: new_retention_days,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert (
+        coordinator.retention_days == new_retention_days
+    ), "Coordinator should reflect new retention_days"
+    assert coordinator.data is not None, "Coordinator should have refreshed data"
+    assert (
+        init_integration.options[CONF_RETENTION_DAYS] == new_retention_days
+    ), "Config entry options should be updated"
+
+
+async def test_pattern_change_updates_scan_results(
+    hass: HomeAssistant, init_integration, tmp_path
+):
+    """Test changing pattern affects scan results when entities are implemented."""
+    coordinator = init_integration.runtime_data
+    media_dir = tmp_path / "media" / "pattern_test"
+    media_dir.mkdir(parents=True)
+
+    for i in range(5):
+        (media_dir / f"file_{i}.jpg").touch()
+        (media_dir / f"file_{i}.png").touch()
+
+    original_pattern = coordinator.pattern
+    assert original_pattern == "*.jpg", "Initial pattern should be *.jpg"
+
+    await coordinator.async_update_config_value(CONF_PATTERN, "*.png")
+    await hass.async_block_till_done()
+
+    assert coordinator.pattern == "*.png", "Pattern should be updated"
+    assert coordinator.data is not None, "Coordinator should have refreshed"
+
+
+async def test_config_change_during_cleanup_uses_snapshot(
+    hass: HomeAssistant, init_integration, tmp_path
+):
+    """Test config changes during cleanup don't affect current operation using ConfigSnapshot."""
+    coordinator = init_integration.runtime_data
+    media_dir = tmp_path / "media" / "snapshot_test"
+    media_dir.mkdir(parents=True)
+
+    for i in range(10):
+        file = media_dir / f"test_{i}.log"
+        file.write_text(f"content {i}")
+        old_time = time_module.time() - (8 * 24 * 60 * 60)
+        os.utime(file, (old_time, old_time))
+
+    snapshot_before = coordinator.create_config_snapshot()
+    assert (
+        snapshot_before.retention_days == 7
+    ), "Snapshot should capture initial retention_days"
+    assert snapshot_before.pattern == "*.jpg", "Snapshot should capture initial pattern"
+    assert snapshot_before.dry_run is True, "Snapshot should capture initial dry_run"
+    assert (
+        snapshot_before.base_path == TEST_MEDIA_PATH
+    ), "Snapshot should capture base_path"
+
+    await coordinator.async_update_config_value(CONF_RETENTION_DAYS, 30)
+    await hass.async_block_till_done()
+
+    snapshot_after = coordinator.create_config_snapshot()
+    assert (
+        snapshot_after.retention_days == 30
+    ), "New snapshot should have updated retention_days"
+    assert (
+        snapshot_before.retention_days == 7
+    ), "Original snapshot should remain unchanged (frozen)"
+
+    try:
+        snapshot_before.retention_days = 99
+        pytest.fail("Should not be able to modify frozen dataclass")
+    except (AttributeError, Exception):
+        pass
+
+
+async def test_run_at_change_updates_scheduler(hass: HomeAssistant, init_integration):
+    """Test changing run_at via coordinator triggers scheduler update."""
+    coordinator = init_integration.runtime_data
+
+    original_run_at = coordinator.run_at
+    assert str(original_run_at) == "02:00:00", "Initial run_at should be 02:00:00"
+
+    new_run_at = "04:30"
+    await coordinator.async_update_config_value(CONF_RUN_AT, new_run_at)
+    await hass.async_block_till_done()
+
+    updated_run_at = coordinator.run_at
+    assert str(updated_run_at) == "04:30:00", "Coordinator run_at should be updated"
+    assert (
+        init_integration.options[CONF_RUN_AT] == new_run_at
+    ), "Config entry options should be updated"
+
+
+async def test_multiple_config_changes_in_sequence(
+    hass: HomeAssistant, init_integration
+):
+    """Test multiple config changes work correctly in sequence."""
+    coordinator = init_integration.runtime_data
+
+    await coordinator.async_update_config_value(CONF_RETENTION_DAYS, 14)
+    await hass.async_block_till_done()
+    assert coordinator.retention_days == 14, "First change should apply"
+
+    await coordinator.async_update_config_value(CONF_PATTERN, "*.log")
+    await hass.async_block_till_done()
+    assert coordinator.pattern == "*.log", "Second change should apply"
+    assert coordinator.retention_days == 14, "First change should persist"
+
+    await coordinator.async_update_config_value(CONF_RUN_AT, "06:00")
+    await hass.async_block_till_done()
+    assert str(coordinator.run_at) == "06:00:00", "Third change should apply"
+    assert coordinator.pattern == "*.log", "Second change should persist"
+    assert coordinator.retention_days == 14, "First change should persist"
+
+
+async def test_dry_run_toggle_via_coordinator(hass: HomeAssistant, init_integration):
+    """Test dry_run toggle via coordinator affects cleanup behavior."""
+    coordinator = init_integration.runtime_data
+
+    assert coordinator.dry_run is True, "Initial dry_run should be True"
+
+    await coordinator.async_update_config_value(CONF_DRY_RUN, False)
+    await hass.async_block_till_done()
+
+    assert coordinator.dry_run is False, "dry_run should be toggled to False"
+    assert (
+        init_integration.options[CONF_DRY_RUN] is False
+    ), "Config entry should reflect change"
+
+    await coordinator.async_update_config_value(CONF_DRY_RUN, True)
+    await hass.async_block_till_done()
+
+    assert coordinator.dry_run is True, "dry_run should toggle back to True"
+
+
+async def test_config_changes_affect_scan_results(
+    hass: HomeAssistant, init_integration, tmp_path
+):
+    """Test config changes are reflected in scan results."""
+    coordinator = init_integration.runtime_data
+    media_dir = tmp_path / "media" / "scan_results"
+    media_dir.mkdir(parents=True)
+
+    for i in range(15):
+        file = media_dir / f"test_{i}.jpg"
+        file.touch()
+        if i < 10:
+            old_time = time_module.time() - (8 * 24 * 60 * 60)
+            os.utime(file, (old_time, old_time))
+
+    with (
+        patch("pathlib.Path.exists", return_value=True),
+        patch("pathlib.Path.is_dir", return_value=True),
+        patch("pathlib.Path.glob") as mock_glob,
+    ):
+        mock_files = [media_dir / f"test_{i}.jpg" for i in range(15)]
+        mock_glob.return_value = mock_files
+
+        await coordinator.async_refresh()
+        await hass.async_block_till_done()
+
+    await coordinator.async_update_config_value(CONF_RETENTION_DAYS, 30)
+    await hass.async_block_till_done()
+
+    assert coordinator.retention_days == 30, "Retention should be updated"
+
+
+async def test_config_persistence_across_coordinator_reload(
+    hass: HomeAssistant, init_integration
+):
+    """Test config changes persist across coordinator operations."""
+    coordinator = init_integration.runtime_data
+
+    await coordinator.async_update_config_value(CONF_RETENTION_DAYS, 21)
+    await hass.async_block_till_done()
+
+    assert init_integration.options[CONF_RETENTION_DAYS] == 21, "Options should persist"
+
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert coordinator.retention_days == 21, "Config should persist after refresh"
+
+
+async def test_all_config_entities_load_correctly(
+    hass: HomeAssistant, init_integration
+):
+    """Test all config entities load correctly on integration setup."""
+    state = hass.states.get("number.test_cleanup_retention_days")
+    assert state is not None, "retention_days Number entity should exist"
+    assert float(state.state) == 7.0, "Initial value should match config"
+
+
+async def test_config_changes_are_atomic(hass: HomeAssistant, init_integration):
+    """Test config changes are atomic (no partial updates)."""
+    coordinator = init_integration.runtime_data
+
+    original_pattern = coordinator.pattern
+
+    await coordinator.async_update_config_value(CONF_RETENTION_DAYS, 25)
+    await hass.async_block_till_done()
+
+    assert coordinator.retention_days == 25, "New value should apply"
+    assert (
+        coordinator.pattern == original_pattern
+    ), "Other config should remain unchanged"
+    assert (
+        init_integration.options[CONF_RETENTION_DAYS] == 25
+    ), "Options should be updated atomically"
+
+
+async def test_retention_days_entity_reflects_coordinator_changes(
+    hass: HomeAssistant, init_integration
+):
+    """Test Number entity state updates when coordinator config changes."""
+    coordinator = init_integration.runtime_data
+
+    await coordinator.async_update_config_value(CONF_RETENTION_DAYS, 42)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("number.test_cleanup_retention_days")
+    assert state is not None, "Number entity should exist"
+    assert float(state.state) == 42.0, "Entity state should reflect updated config"
+
+
+async def test_config_snapshot_immutability(hass: HomeAssistant, init_integration):
+    """Test ConfigSnapshot is truly immutable (frozen dataclass)."""
+    coordinator = init_integration.runtime_data
+
+    snapshot = coordinator.create_config_snapshot()
+
+    with pytest.raises((AttributeError, Exception)):
+        snapshot.retention_days = 999
+
+    with pytest.raises((AttributeError, Exception)):
+        snapshot.pattern = "modified"
+
+    with pytest.raises((AttributeError, Exception)):
+        snapshot.dry_run = False
+
+
+async def test_config_snapshot_captures_all_fields(
+    hass: HomeAssistant, init_integration
+):
+    """Test ConfigSnapshot captures all config fields correctly."""
+    coordinator = init_integration.runtime_data
+
+    snapshot = coordinator.create_config_snapshot()
+
+    assert hasattr(snapshot, "base_path"), "Should have base_path"
+    assert hasattr(snapshot, "pattern"), "Should have pattern"
+    assert hasattr(snapshot, "retention_days"), "Should have retention_days"
+    assert hasattr(snapshot, "dry_run"), "Should have dry_run"
+    assert hasattr(snapshot, "max_deletes"), "Should have max_deletes"
+    assert hasattr(snapshot, "run_at"), "Should have run_at"
+    assert hasattr(snapshot, "only_extensions"), "Should have only_extensions"
+    assert hasattr(snapshot, "except_extensions"), "Should have except_extensions"
+    assert hasattr(snapshot, "keep_minimum_files"), "Should have keep_minimum_files"
+    assert hasattr(snapshot, "max_files_in_folder"), "Should have max_files_in_folder"
+    assert hasattr(snapshot, "remove_empty_folders"), "Should have remove_empty_folders"
+
+    assert snapshot.base_path == TEST_MEDIA_PATH, "base_path should match"
+    assert snapshot.pattern == "*.jpg", "pattern should match"
+    assert snapshot.retention_days == 7, "retention_days should match"
+    assert snapshot.dry_run is True, "dry_run should match"
+    assert snapshot.max_deletes == 100, "max_deletes should match"
+
+
+async def test_concurrent_config_changes(hass: HomeAssistant, init_integration):
+    """Test multiple concurrent config changes are handled correctly."""
+    coordinator = init_integration.runtime_data
+
+    tasks = [
+        coordinator.async_update_config_value(CONF_RETENTION_DAYS, 15),
+        coordinator.async_update_config_value(CONF_PATTERN, "*.png"),
+    ]
+
+    await asyncio.gather(*tasks)
+    await hass.async_block_till_done()
+
+    assert coordinator.retention_days == 15, "First change should apply"
+    assert coordinator.pattern == "*.png", "Second change should apply"
+
+
+async def test_config_change_triggers_refresh_once(
+    hass: HomeAssistant, init_integration
+):
+    """Test config change triggers exactly one coordinator refresh."""
+    coordinator = init_integration.runtime_data
+
+    initial_scan_time = coordinator.last_scan
+
+    await coordinator.async_update_config_value(CONF_RETENTION_DAYS, 20)
+    await hass.async_block_till_done()
+
+    updated_scan_time = coordinator.last_scan
+
+    assert updated_scan_time != initial_scan_time, "Scan should have been triggered"
+
+
+async def test_config_update_with_invalid_key(hass: HomeAssistant, init_integration):
+    """Test coordinator handles invalid config keys gracefully."""
+    coordinator = init_integration.runtime_data
+
+    await coordinator.async_update_config_value("invalid_key", "invalid_value")
+    await hass.async_block_till_done()
+
+    assert coordinator.data is not None, "Coordinator should still function"
+
+
+async def test_scheduler_removed_on_shutdown(hass: HomeAssistant, init_integration):
+    """Test scheduler listeners are removed on coordinator shutdown."""
+    coordinator = init_integration.runtime_data
+
+    await coordinator.async_setup_daily_schedule()
+    await hass.async_block_till_done()
+
+    assert coordinator._unsub_daily is not None, "Scheduler should be active"
+
+    await coordinator.async_shutdown()
+    await hass.async_block_till_done()
+
+    assert coordinator._unsub_daily is None, "Scheduler should be removed"
+
+
+async def test_config_change_during_scan_does_not_affect_scan(
+    hass: HomeAssistant, init_integration, tmp_path
+):
+    """Test config changes during scan operation use snapshot for consistency."""
+    coordinator = init_integration.runtime_data
+    media_dir = tmp_path / "media" / "concurrent_test"
+    media_dir.mkdir(parents=True)
+
+    for i in range(20):
+        file = media_dir / f"test_{i}.jpg"
+        file.touch()
+
+    snapshot_before_scan = coordinator.create_config_snapshot()
+
+    async def change_config_during_operation():
+        await asyncio.sleep(0.01)
+        await coordinator.async_update_config_value(CONF_RETENTION_DAYS, 99)
+
+    with (
+        patch("pathlib.Path.exists", return_value=True),
+        patch("pathlib.Path.is_dir", return_value=True),
+        patch(
+            "pathlib.Path.glob",
+            return_value=[media_dir / f"test_{i}.jpg" for i in range(20)],
+        ),
+    ):
+        await asyncio.gather(
+            coordinator.async_refresh(),
+            change_config_during_operation(),
+        )
+        await hass.async_block_till_done()
+
+    assert (
+        snapshot_before_scan.retention_days == 7
+    ), "Original snapshot should be unchanged"
+    assert coordinator.retention_days == 99, "Current config should reflect change"
+
+
+async def test_config_entry_options_sync_with_coordinator(
+    hass: HomeAssistant, init_integration
+):
+    """Test config entry options stay in sync with coordinator config."""
+    coordinator = init_integration.runtime_data
+
+    await coordinator.async_update_config_value(CONF_RETENTION_DAYS, 35)
+    await hass.async_block_till_done()
+
+    assert (
+        init_integration.options[CONF_RETENTION_DAYS] == 35
+    ), "Options should sync immediately"
+    assert coordinator.retention_days == 35, "Coordinator should reflect change"
+
+    assert (
+        coordinator.cfg[CONF_RETENTION_DAYS] == 35
+    ), "Merged cfg property should show update"
+
+
+async def test_multiple_rapid_config_changes(hass: HomeAssistant, init_integration):
+    """Test rapid sequential config changes don't cause issues."""
+    coordinator = init_integration.runtime_data
+
+    for value in [10, 20, 30, 40, 50]:
+        await coordinator.async_update_config_value(CONF_RETENTION_DAYS, value)
+
+    await hass.async_block_till_done()
+
+    assert coordinator.retention_days == 50, "Final value should apply"
+    assert (
+        init_integration.options[CONF_RETENTION_DAYS] == 50
+    ), "Options should reflect final value"
+
+
+async def test_config_change_preserves_other_options(
+    hass: HomeAssistant, init_integration
+):
+    """Test updating one config value doesn't affect other options."""
+    coordinator = init_integration.runtime_data
+
+    original_pattern = coordinator.pattern
+    original_max_deletes = coordinator.max_deletes
+    original_dry_run = coordinator.dry_run
+
+    await coordinator.async_update_config_value(CONF_RETENTION_DAYS, 28)
+    await hass.async_block_till_done()
+
+    assert coordinator.retention_days == 28, "Updated value should apply"
+    assert coordinator.pattern == original_pattern, "pattern should be unchanged"
+    assert (
+        coordinator.max_deletes == original_max_deletes
+    ), "max_deletes should be unchanged"
+    assert coordinator.dry_run == original_dry_run, "dry_run should be unchanged"
+
+
+async def test_dry_run_toggle_via_switch(hass: HomeAssistant, init_integration):
+    """Test dry_run toggle via switch entity (migrated from select)."""
+    coordinator = init_integration.runtime_data
+
+    assert coordinator.dry_run is True, "Should start as True"
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "switch.test_cleanup_dry_run"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_cleanup_dry_run")
+    assert state.state == "off", "State should be off"
+    assert coordinator.dry_run is False, "Coordinator should be False"
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "switch.test_cleanup_dry_run"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_cleanup_dry_run")
+    assert state.state == "on", "State should be on"
+    assert coordinator.dry_run is True, "Coordinator should be True"
+
+
+async def test_remove_empty_folders_toggle(hass: HomeAssistant, init_integration):
+    """Test remove_empty_folders switch toggles correctly."""
+    coordinator = init_integration.runtime_data
+
+    assert coordinator.remove_empty_folders is False, "Should start as False"
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "switch.test_cleanup_remove_empty_folders"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_cleanup_remove_empty_folders")
+    assert state.state == "on", "State should be on"
+    assert coordinator.remove_empty_folders is True, "Coordinator should be True"
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "switch.test_cleanup_remove_empty_folders"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_cleanup_remove_empty_folders")
+    assert state.state == "off", "State should be off"
+    assert coordinator.remove_empty_folders is False, "Coordinator should be False"
+
+
+async def test_max_deletes_change_triggers_scan(hass: HomeAssistant, init_integration):
+    """Test changing max_deletes triggers coordinator refresh."""
+    coordinator = init_integration.runtime_data
+
+    initial_last_scan = coordinator.data.get("last_scan")
+    initial_max_deletes = coordinator.max_deletes
+    assert initial_max_deletes == 100, "Initial max_deletes should be 100"
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        NUMBER_SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: "number.test_cleanup_max_deletes",
+            NUMBER_ATTR_VALUE: 500,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert coordinator.max_deletes == 500, "max_deletes should be updated"
+
+    new_last_scan = coordinator.data.get("last_scan")
+    assert new_last_scan != initial_last_scan, "Scan should have been triggered"
+
+
+async def test_keep_minimum_files_change(hass: HomeAssistant, init_integration):
+    """Test changing keep_minimum_files updates coordinator."""
+    coordinator = init_integration.runtime_data
+
+    initial_keep_minimum = coordinator.keep_minimum_files
+    assert initial_keep_minimum == 5, "Initial keep_minimum_files should be 5"
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        NUMBER_SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: "number.test_cleanup_keep_minimum_files",
+            NUMBER_ATTR_VALUE: 100,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert coordinator.keep_minimum_files == 100, "keep_minimum_files should be 100"
+    assert (
+        init_integration.options[CONF_KEEP_MINIMUM_FILES] == 100
+    ), "Config entry options should be updated"
+
+
+async def test_max_files_in_folder_zero_unlimited(
+    hass: HomeAssistant, init_integration
+):
+    """Test that max_files_in_folder can be set to 0 (unlimited)."""
+    coordinator = init_integration.runtime_data
+
+    initial_max_files = coordinator.max_files_in_folder
+    assert initial_max_files == 50, "Initial max_files_in_folder should be 50"
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        NUMBER_SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: "number.test_cleanup_max_files_in_folder",
+            NUMBER_ATTR_VALUE: 0,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert coordinator.max_files_in_folder == 0, "Should accept 0 (unlimited)"
+    assert (
+        init_integration.options[CONF_MAX_FILES_IN_FOLDER] == 0
+    ), "Config entry should reflect 0"
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        NUMBER_SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: "number.test_cleanup_max_files_in_folder",
+            NUMBER_ATTR_VALUE: 10000,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert coordinator.max_files_in_folder == 10000, "Should accept 10000"
+    assert (
+        init_integration.options[CONF_MAX_FILES_IN_FOLDER] == 10000
+    ), "Config entry should reflect 10000"
+
+
+async def test_all_new_config_entities_exist(hass: HomeAssistant, init_integration):
+    """Test all new config entities are created."""
+    new_entities = [
+        "switch.test_cleanup_dry_run",
+        "switch.test_cleanup_remove_empty_folders",
+        "number.test_cleanup_max_deletes",
+        "number.test_cleanup_keep_minimum_files",
+        "number.test_cleanup_max_files_in_folder",
+    ]
+
+    for entity_id in new_entities:
+        state = hass.states.get(entity_id)
+        assert state is not None, f"Entity {entity_id} should exist"
+
+
+async def test_config_snapshot_includes_new_values(
+    hass: HomeAssistant, init_integration
+):
+    """Test ConfigSnapshot includes all new config values."""
+    coordinator = init_integration.runtime_data
+
+    snapshot = coordinator.create_config_snapshot()
+
+    assert hasattr(snapshot, "max_deletes"), "Snapshot should have max_deletes"
+    assert hasattr(
+        snapshot, "keep_minimum_files"
+    ), "Snapshot should have keep_minimum_files"
+    assert hasattr(
+        snapshot, "max_files_in_folder"
+    ), "Snapshot should have max_files_in_folder"
+    assert hasattr(
+        snapshot, "remove_empty_folders"
+    ), "Snapshot should have remove_empty_folders"
+
+    assert (
+        snapshot.max_deletes == coordinator.max_deletes
+    ), "Snapshot max_deletes should match coordinator"
+    assert (
+        snapshot.keep_minimum_files == coordinator.keep_minimum_files
+    ), "Snapshot keep_minimum_files should match coordinator"
+    assert (
+        snapshot.max_files_in_folder == coordinator.max_files_in_folder
+    ), "Snapshot max_files_in_folder should match coordinator"
+    assert (
+        snapshot.remove_empty_folders == coordinator.remove_empty_folders
+    ), "Snapshot remove_empty_folders should match coordinator"
+
+
+async def test_switch_changes_trigger_config_entry_update(
+    hass: HomeAssistant, init_integration
+):
+    """Test switch changes persist to config entry options."""
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "switch.test_cleanup_dry_run"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert (
+        init_integration.options[CONF_DRY_RUN] is False
+    ), "Config entry should reflect dry_run off"
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "switch.test_cleanup_remove_empty_folders"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert (
+        init_integration.options[CONF_REMOVE_EMPTY_FOLDERS] is True
+    ), "Config entry should reflect remove_empty_folders on"
+
+
+async def test_number_entities_update_coordinator_via_service(
+    hass: HomeAssistant, init_integration
+):
+    """Test Number entity service calls update coordinator values."""
+    coordinator = init_integration.runtime_data
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        NUMBER_SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: "number.test_cleanup_max_deletes",
+            NUMBER_ATTR_VALUE: 250,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert coordinator.max_deletes == 250, "Coordinator max_deletes should be updated"
+    assert (
+        init_integration.options[CONF_MAX_DELETES] == 250
+    ), "Config entry should be updated"
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        NUMBER_SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: "number.test_cleanup_keep_minimum_files",
+            NUMBER_ATTR_VALUE: 15,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert (
+        coordinator.keep_minimum_files == 15
+    ), "Coordinator keep_minimum_files should be updated"
+    assert (
+        init_integration.options[CONF_KEEP_MINIMUM_FILES] == 15
+    ), "Config entry should be updated"
+
+
+async def test_multiple_entity_changes_in_sequence(
+    hass: HomeAssistant, init_integration
+):
+    """Test multiple config entity changes work correctly in sequence."""
+    coordinator = init_integration.runtime_data
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        NUMBER_SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: "number.test_cleanup_max_deletes",
+            NUMBER_ATTR_VALUE: 300,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert coordinator.max_deletes == 300, "First change should apply"
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "switch.test_cleanup_dry_run"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert coordinator.dry_run is False, "Second change should apply"
+    assert coordinator.max_deletes == 300, "First change should persist"
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        NUMBER_SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: "number.test_cleanup_keep_minimum_files",
+            NUMBER_ATTR_VALUE: 20,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert coordinator.keep_minimum_files == 20, "Third change should apply"
+    assert coordinator.dry_run is False, "Second change should persist"
+    assert coordinator.max_deletes == 300, "First change should persist"
+
+
+async def test_switch_entity_states_on_load(hass: HomeAssistant, init_integration):
+    """Test switch entities load with correct initial states."""
+    dry_run_state = hass.states.get("switch.test_cleanup_dry_run")
+    assert dry_run_state is not None, "dry_run switch should exist"
+    assert dry_run_state.state == "on", "dry_run should start on (True)"
+
+    remove_empty_state = hass.states.get("switch.test_cleanup_remove_empty_folders")
+    assert remove_empty_state is not None, "remove_empty_folders switch should exist"
+    assert (
+        remove_empty_state.state == "off"
+    ), "remove_empty_folders should start off (False)"
+
+
+async def test_number_entity_states_on_load(hass: HomeAssistant, init_integration):
+    """Test number entities load with correct initial values."""
+    max_deletes_state = hass.states.get("number.test_cleanup_max_deletes")
+    assert max_deletes_state is not None, "max_deletes number should exist"
+    assert float(max_deletes_state.state) == 100.0, "max_deletes should start at 100"
+
+    keep_minimum_state = hass.states.get("number.test_cleanup_keep_minimum_files")
+    assert keep_minimum_state is not None, "keep_minimum_files number should exist"
+    assert (
+        float(keep_minimum_state.state) == 5.0
+    ), "keep_minimum_files should start at 5"
+
+    max_files_state = hass.states.get("number.test_cleanup_max_files_in_folder")
+    assert max_files_state is not None, "max_files_in_folder number should exist"
+    assert (
+        float(max_files_state.state) == 50.0
+    ), "max_files_in_folder should start at 50"
+
+
+async def test_config_snapshot_frozen_with_new_fields(
+    hass: HomeAssistant, init_integration
+):
+    """Test ConfigSnapshot is immutable with new fields."""
+    coordinator = init_integration.runtime_data
+
+    snapshot = coordinator.create_config_snapshot()
+
+    with pytest.raises((AttributeError, Exception)):
+        snapshot.max_deletes = 999
+
+    with pytest.raises((AttributeError, Exception)):
+        snapshot.keep_minimum_files = 999
+
+    with pytest.raises((AttributeError, Exception)):
+        snapshot.max_files_in_folder = 999
+
+    with pytest.raises((AttributeError, Exception)):
+        snapshot.remove_empty_folders = True

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,0 +1,952 @@
+"""Test retention_cleaner number entities."""
+
+from unittest.mock import patch
+
+from homeassistant.components.number import (
+    ATTR_VALUE,
+    DOMAIN as NUMBER_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.const import ATTR_ENTITY_ID, EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+import pytest
+
+from custom_components.retention_cleaner.const import (
+    CONF_KEEP_MINIMUM_FILES,
+    CONF_MAX_DELETES,
+    CONF_MAX_FILES_IN_FOLDER,
+    CONF_RETENTION_DAYS,
+    DOMAIN,
+)
+
+
+async def test_number_entity_setup(hass: HomeAssistant, init_integration):
+    """Test number entity is created during platform setup."""
+    state = hass.states.get("number.test_cleanup_retention_days")
+    assert state is not None, "retention_days number entity should exist"
+
+
+async def test_number_entity_initial_value(hass: HomeAssistant, init_integration):
+    """Test initial value matches coordinator config."""
+    coordinator = init_integration.runtime_data
+
+    state = hass.states.get("number.test_cleanup_retention_days")
+    assert state is not None, "retention_days number entity should exist"
+    assert (
+        float(state.state) == coordinator.retention_days
+    ), "Initial value should match coordinator config"
+
+
+async def test_number_entity_set_value(hass: HomeAssistant, init_integration):
+    """Test setting value updates the entity state."""
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: "number.test_cleanup_retention_days", ATTR_VALUE: 14},
+        blocking=True,
+    )
+
+    state = hass.states.get("number.test_cleanup_retention_days")
+    assert state is not None, "Number entity should still exist"
+    assert float(state.state) == 14, "State should be updated to new value"
+
+
+async def test_number_entity_set_value_updates_config(
+    hass: HomeAssistant, init_integration
+):
+    """Test config is persisted via async_update_config_value."""
+    coordinator = init_integration.runtime_data
+
+    with (
+        patch.object(coordinator, "async_update_config_value") as mock_update_config,
+        patch.object(hass.config_entries, "async_update_entry"),
+    ):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: "number.test_cleanup_retention_days", ATTR_VALUE: 21},
+            blocking=True,
+        )
+
+        mock_update_config.assert_called_once_with(CONF_RETENTION_DAYS, 21)
+
+
+async def test_number_entity_set_value_triggers_scan(
+    hass: HomeAssistant, init_integration
+):
+    """Test coordinator refresh is triggered."""
+    coordinator = init_integration.runtime_data
+
+    initial_last_scan = coordinator.last_scan
+
+    with patch.object(hass.config_entries, "async_update_entry"):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: "number.test_cleanup_retention_days", ATTR_VALUE: 30},
+            blocking=True,
+        )
+
+    assert (
+        coordinator.last_scan != initial_last_scan
+    ), "Coordinator should have refreshed"
+
+
+async def test_number_entity_min_max_validation(hass: HomeAssistant, init_integration):
+    """Test min (1) and max (3650) boundaries are respected."""
+    registry = er.async_get(hass)
+
+    entry = registry.async_get("number.test_cleanup_retention_days")
+    assert entry is not None, "Number entity should exist in registry"
+
+    state = hass.states.get("number.test_cleanup_retention_days")
+    assert state is not None, "Number entity state should exist"
+
+    assert state.attributes.get("min") == 1, "Min value should be 1"
+    assert state.attributes.get("max") == 3650, "Max value should be 3650"
+    assert state.attributes.get("step") == 1, "Step value should be 1"
+
+
+async def test_number_entity_attributes(hass: HomeAssistant, init_integration):
+    """Test number entity attributes and configuration."""
+    registry = er.async_get(hass)
+
+    entry = registry.async_get("number.test_cleanup_retention_days")
+    assert entry is not None, "Number entity should exist in registry"
+    assert (
+        entry.unique_id == f"{init_integration.entry_id}_retention_days"
+    ), "Should have correct unique_id format"
+    assert (
+        entry.entity_category == EntityCategory.CONFIG
+    ), "Should have CONFIG entity category"
+
+    state = hass.states.get("number.test_cleanup_retention_days")
+    assert state is not None, "Number entity state should exist"
+    assert (
+        state.attributes.get("unit_of_measurement") == "days"
+    ), "Should have 'days' unit"
+    assert (
+        state.attributes.get("mode") == "box"
+    ), "Should have 'box' mode for text input"
+
+
+async def test_number_entity_device_info(hass: HomeAssistant, init_integration):
+    """Test that number entity is linked to the correct device."""
+    registry = er.async_get(hass)
+
+    entry = registry.async_get("number.test_cleanup_retention_days")
+    assert entry is not None, "Number entity should exist"
+    assert entry.device_id is not None, "Should be linked to device"
+
+    try:
+        device_registry = hass.helpers.device_registry.async_get()
+    except TypeError:
+        device_registry = hass.helpers.device_registry.async_get(hass)
+
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, init_integration.entry_id)}
+    )
+    assert device is not None, "Device should exist"
+    assert device.name == "Test Cleanup", "Device should have correct name"
+    assert device.model == "Folder retention rule", "Device should have correct model"
+    assert (
+        device.manufacturer == "Retention Cleaner"
+    ), "Device should have correct manufacturer"
+    assert (
+        DOMAIN,
+        init_integration.entry_id,
+    ) in device.identifiers, "Device should have correct identifiers"
+
+
+async def test_number_entity_unique_id_stable(hass: HomeAssistant, init_integration):
+    """Test that number entity unique ID remains stable."""
+    registry = er.async_get(hass)
+    entry_id = init_integration.entry_id
+
+    entity_id = registry.async_get_entity_id(
+        NUMBER_DOMAIN, DOMAIN, f"{entry_id}_retention_days"
+    )
+    assert entity_id is not None, "Number entity should be found by unique_id"
+    assert (
+        entity_id == "number.test_cleanup_retention_days"
+    ), "Should have correct entity_id"
+
+
+async def test_number_entity_updates_from_coordinator(
+    hass: HomeAssistant, init_integration
+):
+    """Test that number entity reflects coordinator config changes."""
+    coordinator = init_integration.runtime_data
+
+    await coordinator.async_update_config_value(CONF_RETENTION_DAYS, 45)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("number.test_cleanup_retention_days")
+    assert state is not None, "Number entity should still exist"
+    assert float(state.state) == 45, "State should reflect updated coordinator config"
+
+
+async def test_number_entity_boundary_values(hass: HomeAssistant):
+    """Test setting boundary values (min=1, max=3650)."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    entry_min = MockConfigEntry(
+        domain="retention_cleaner",
+        title="Test Min Retention",
+        data={
+            "base_path": "/media/test",
+            "pattern": "*.jpg",
+            "retention_days": 1,
+            "dry_run": True,
+            "max_deletes": 100,
+            "run_at": "02:00",
+        },
+        entry_id="test_min_entry",
+    )
+    entry_min.add_to_hass(hass)
+
+    with (
+        patch("pathlib.Path.exists", return_value=True),
+        patch("pathlib.Path.is_dir", return_value=True),
+        patch("pathlib.Path.glob", return_value=[]),
+    ):
+        assert await hass.config_entries.async_setup(entry_min.entry_id)
+        await hass.async_block_till_done()
+
+    state_min = hass.states.get("number.test_min_retention_retention_days")
+    assert float(state_min.state) == 1, "Should accept minimum value of 1"
+
+    entry_max = MockConfigEntry(
+        domain="retention_cleaner",
+        title="Test Max Retention",
+        data={
+            "base_path": "/media/test",
+            "pattern": "*.jpg",
+            "retention_days": 3650,
+            "dry_run": True,
+            "max_deletes": 100,
+            "run_at": "02:00",
+        },
+        entry_id="test_max_entry",
+    )
+    entry_max.add_to_hass(hass)
+
+    with (
+        patch("pathlib.Path.exists", return_value=True),
+        patch("pathlib.Path.is_dir", return_value=True),
+        patch("pathlib.Path.glob", return_value=[]),
+    ):
+        assert await hass.config_entries.async_setup(entry_max.entry_id)
+        await hass.async_block_till_done()
+
+    state_max = hass.states.get("number.test_max_retention_retention_days")
+    assert float(state_max.state) == 3650, "Should accept maximum value of 3650"
+
+
+async def test_number_entity_multiple_updates(hass: HomeAssistant, init_integration):
+    """Test multiple value updates work correctly."""
+    coordinator = init_integration.runtime_data
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: "number.test_cleanup_retention_days",
+            ATTR_VALUE: 30,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("number.test_cleanup_retention_days")
+    assert float(state.state) == 30, "Should update to 30 days"
+    assert coordinator.retention_days == 30, "Coordinator should have 30 days"
+
+
+async def test_number_entity_availability(hass: HomeAssistant, init_integration):
+    """Test number entity availability based on coordinator."""
+    coordinator = init_integration.runtime_data
+
+    state = hass.states.get("number.test_cleanup_retention_days")
+    assert state.state != "unavailable", "Should be available when coordinator is ready"
+
+    coordinator.async_set_updated_data(None)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("number.test_cleanup_retention_days")
+    assert (
+        state.state != "unavailable"
+    ), "Number entity should remain available even with no coordinator data"
+
+
+# ==================== MAX_DELETES NUMBER ENTITY TESTS ====================
+
+
+async def test_number_max_deletes_setup(hass: HomeAssistant, init_integration):
+    """Test max_deletes number entity is created during platform setup."""
+    state = hass.states.get("number.test_cleanup_max_deletes")
+    assert state is not None, "max_deletes number entity should exist"
+
+
+async def test_number_max_deletes_initial_value(hass: HomeAssistant, init_integration):
+    """Test initial value matches coordinator config."""
+    coordinator = init_integration.runtime_data
+
+    state = hass.states.get("number.test_cleanup_max_deletes")
+    assert state is not None, "max_deletes entity should exist"
+
+    assert (
+        float(state.state) == coordinator.max_deletes
+    ), "Initial value should match coordinator"
+
+
+async def test_number_max_deletes_set_value(hass: HomeAssistant, init_integration):
+    """Test setting value via number.set_value service."""
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: "number.test_cleanup_max_deletes",
+            ATTR_VALUE: 500,
+        },
+        blocking=True,
+    )
+
+    state = hass.states.get("number.test_cleanup_max_deletes")
+    assert state is not None, "Entity should still exist after update"
+    assert float(state.state) == 500, "State should be updated to 500"
+
+
+async def test_number_max_deletes_set_value_updates_config(
+    hass: HomeAssistant, init_integration
+):
+    """Test config is persisted via async_update_config_value."""
+    coordinator = init_integration.runtime_data
+
+    with (
+        patch.object(coordinator, "async_update_config_value") as mock_update_config,
+        patch.object(hass.config_entries, "async_update_entry"),
+    ):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: "number.test_cleanup_max_deletes", ATTR_VALUE: 2000},
+            blocking=True,
+        )
+
+        mock_update_config.assert_called_once_with(CONF_MAX_DELETES, 2000)
+
+
+async def test_number_max_deletes_set_value_triggers_scan(
+    hass: HomeAssistant, init_integration
+):
+    """Test coordinator refresh is triggered."""
+    coordinator = init_integration.runtime_data
+
+    initial_last_scan = coordinator.last_scan
+
+    with patch.object(hass.config_entries, "async_update_entry"):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: "number.test_cleanup_max_deletes", ATTR_VALUE: 3000},
+            blocking=True,
+        )
+
+    assert (
+        coordinator.last_scan != initial_last_scan
+    ), "Coordinator should have refreshed"
+
+
+async def test_number_max_deletes_min_max_validation(
+    hass: HomeAssistant, init_integration
+):
+    """Test min (1) and max (10000) boundaries are enforced."""
+    registry = er.async_get(hass)
+
+    entry = registry.async_get("number.test_cleanup_max_deletes")
+    assert entry is not None, "max_deletes entity should exist in registry"
+
+    state = hass.states.get("number.test_cleanup_max_deletes")
+    assert state is not None, "max_deletes entity state should exist"
+
+    assert state.attributes.get("min") == 1, "Min value should be 1"
+    assert state.attributes.get("max") == 10000, "Max value should be 10000"
+    assert state.attributes.get("step") == 1, "Step value should be 1"
+
+
+async def test_number_max_deletes_attributes(hass: HomeAssistant, init_integration):
+    """Test max_deletes entity attributes and configuration."""
+    registry = er.async_get(hass)
+
+    entry = registry.async_get("number.test_cleanup_max_deletes")
+    assert entry is not None, "max_deletes entity should exist in registry"
+    assert (
+        entry.unique_id == f"{init_integration.entry_id}_max_deletes"
+    ), "Should have correct unique_id format"
+    assert (
+        entry.entity_category == EntityCategory.CONFIG
+    ), "Should have CONFIG entity category"
+
+    state = hass.states.get("number.test_cleanup_max_deletes")
+    assert state is not None, "max_deletes entity state should exist"
+    assert (
+        state.attributes.get("unit_of_measurement") == "files"
+    ), "Should have 'files' unit"
+    assert (
+        state.attributes.get("mode") == "box"
+    ), "Should have 'box' mode for text input"
+
+
+async def test_number_max_deletes_device_info(hass: HomeAssistant, init_integration):
+    """Test that max_deletes entity is linked to the correct device."""
+    registry = er.async_get(hass)
+
+    entry = registry.async_get("number.test_cleanup_max_deletes")
+    assert entry is not None, "max_deletes entity should exist"
+    assert entry.device_id is not None, "Should be linked to device"
+
+    try:
+        device_registry = hass.helpers.device_registry.async_get()
+    except TypeError:
+        device_registry = hass.helpers.device_registry.async_get(hass)
+
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, init_integration.entry_id)}
+    )
+    assert device is not None, "Device should exist"
+    assert (
+        DOMAIN,
+        init_integration.entry_id,
+    ) in device.identifiers, "Device should have correct identifiers"
+
+
+async def test_number_max_deletes_unique_id_stable(
+    hass: HomeAssistant, init_integration
+):
+    """Test that max_deletes entity unique ID remains stable."""
+    registry = er.async_get(hass)
+    entry_id = init_integration.entry_id
+
+    entity_id = registry.async_get_entity_id(
+        NUMBER_DOMAIN, DOMAIN, f"{entry_id}_max_deletes"
+    )
+    assert entity_id is not None, "max_deletes entity should be found by unique_id"
+    assert (
+        entity_id == "number.test_cleanup_max_deletes"
+    ), "Should have correct entity_id"
+
+
+async def test_number_max_deletes_updates_from_coordinator(
+    hass: HomeAssistant, init_integration
+):
+    """Test that max_deletes entity reflects coordinator config changes."""
+    coordinator = init_integration.runtime_data
+
+    await coordinator.async_update_config_value(CONF_MAX_DELETES, 7500)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("number.test_cleanup_max_deletes")
+    assert state is not None, "max_deletes entity should still exist"
+    assert float(state.state) == 7500, "State should reflect updated coordinator config"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (1, 1),
+        (10000, 10000),
+        (1000, 1000),
+        (5000, 5000),
+    ],
+)
+async def test_number_max_deletes_boundary_values(
+    hass: HomeAssistant, init_integration, value, expected
+):
+    """Test boundary values are accepted."""
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: "number.test_cleanup_max_deletes", ATTR_VALUE: value},
+        blocking=True,
+    )
+
+    state = hass.states.get("number.test_cleanup_max_deletes")
+    assert float(state.state) == expected, f"Should accept value {expected}"
+
+
+# ==================== KEEP_MINIMUM_FILES NUMBER ENTITY TESTS ====================
+
+
+async def test_number_keep_minimum_files_setup(hass: HomeAssistant, init_integration):
+    """Test keep_minimum_files number entity is created during platform setup."""
+    state = hass.states.get("number.test_cleanup_keep_minimum_files")
+    assert state is not None, "keep_minimum_files number entity should exist"
+
+
+async def test_number_keep_minimum_files_initial_value(
+    hass: HomeAssistant, init_integration
+):
+    """Test initial value matches coordinator config."""
+    coordinator = init_integration.runtime_data
+
+    state = hass.states.get("number.test_cleanup_keep_minimum_files")
+    assert state is not None, "keep_minimum_files entity should exist"
+
+    assert (
+        float(state.state) == coordinator.keep_minimum_files
+    ), "Initial value should match coordinator"
+
+
+async def test_number_keep_minimum_files_set_value(
+    hass: HomeAssistant, init_integration
+):
+    """Test setting value via number.set_value service."""
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: "number.test_cleanup_keep_minimum_files",
+            ATTR_VALUE: 100,
+        },
+        blocking=True,
+    )
+
+    state = hass.states.get("number.test_cleanup_keep_minimum_files")
+    assert state is not None, "Entity should still exist after update"
+    assert float(state.state) == 100, "State should be updated to 100"
+
+
+async def test_number_keep_minimum_files_set_value_updates_config(
+    hass: HomeAssistant, init_integration
+):
+    """Test config is persisted via async_update_config_value."""
+    coordinator = init_integration.runtime_data
+
+    with (
+        patch.object(coordinator, "async_update_config_value") as mock_update_config,
+        patch.object(hass.config_entries, "async_update_entry"),
+    ):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: "number.test_cleanup_keep_minimum_files", ATTR_VALUE: 250},
+            blocking=True,
+        )
+
+        mock_update_config.assert_called_once_with(CONF_KEEP_MINIMUM_FILES, 250)
+
+
+async def test_number_keep_minimum_files_set_value_triggers_scan(
+    hass: HomeAssistant, init_integration
+):
+    """Test coordinator refresh is triggered."""
+    coordinator = init_integration.runtime_data
+
+    initial_last_scan = coordinator.last_scan
+
+    with patch.object(hass.config_entries, "async_update_entry"):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: "number.test_cleanup_keep_minimum_files", ATTR_VALUE: 500},
+            blocking=True,
+        )
+
+    assert (
+        coordinator.last_scan != initial_last_scan
+    ), "Coordinator should have refreshed"
+
+
+async def test_number_keep_minimum_files_min_max_validation(
+    hass: HomeAssistant, init_integration
+):
+    """Test min (0) and max (10000) boundaries are enforced."""
+    registry = er.async_get(hass)
+
+    entry = registry.async_get("number.test_cleanup_keep_minimum_files")
+    assert entry is not None, "keep_minimum_files entity should exist in registry"
+
+    state = hass.states.get("number.test_cleanup_keep_minimum_files")
+    assert state is not None, "keep_minimum_files entity state should exist"
+
+    assert state.attributes.get("min") == 0, "Min value should be 0"
+    assert state.attributes.get("max") == 10000, "Max value should be 10000"
+    assert state.attributes.get("step") == 1, "Step value should be 1"
+
+
+async def test_number_keep_minimum_files_attributes(
+    hass: HomeAssistant, init_integration
+):
+    """Test keep_minimum_files entity attributes and configuration."""
+    registry = er.async_get(hass)
+
+    entry = registry.async_get("number.test_cleanup_keep_minimum_files")
+    assert entry is not None, "keep_minimum_files entity should exist in registry"
+    assert (
+        entry.unique_id == f"{init_integration.entry_id}_keep_minimum_files"
+    ), "Should have correct unique_id format"
+    assert (
+        entry.entity_category == EntityCategory.CONFIG
+    ), "Should have CONFIG entity category"
+
+    state = hass.states.get("number.test_cleanup_keep_minimum_files")
+    assert state is not None, "keep_minimum_files entity state should exist"
+    assert (
+        state.attributes.get("unit_of_measurement") == "files"
+    ), "Should have 'files' unit"
+    assert (
+        state.attributes.get("mode") == "box"
+    ), "Should have 'box' mode for text input"
+
+
+async def test_number_keep_minimum_files_device_info(
+    hass: HomeAssistant, init_integration
+):
+    """Test that keep_minimum_files entity is linked to the correct device."""
+    registry = er.async_get(hass)
+
+    entry = registry.async_get("number.test_cleanup_keep_minimum_files")
+    assert entry is not None, "keep_minimum_files entity should exist"
+    assert entry.device_id is not None, "Should be linked to device"
+
+    try:
+        device_registry = hass.helpers.device_registry.async_get()
+    except TypeError:
+        device_registry = hass.helpers.device_registry.async_get(hass)
+
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, init_integration.entry_id)}
+    )
+    assert device is not None, "Device should exist"
+    assert (
+        DOMAIN,
+        init_integration.entry_id,
+    ) in device.identifiers, "Device should have correct identifiers"
+
+
+async def test_number_keep_minimum_files_unique_id_stable(
+    hass: HomeAssistant, init_integration
+):
+    """Test that keep_minimum_files entity unique ID remains stable."""
+    registry = er.async_get(hass)
+    entry_id = init_integration.entry_id
+
+    entity_id = registry.async_get_entity_id(
+        NUMBER_DOMAIN, DOMAIN, f"{entry_id}_keep_minimum_files"
+    )
+    assert (
+        entity_id is not None
+    ), "keep_minimum_files entity should be found by unique_id"
+    assert (
+        entity_id == "number.test_cleanup_keep_minimum_files"
+    ), "Should have correct entity_id"
+
+
+async def test_number_keep_minimum_files_updates_from_coordinator(
+    hass: HomeAssistant, init_integration
+):
+    """Test that keep_minimum_files entity reflects coordinator config changes."""
+    coordinator = init_integration.runtime_data
+
+    await coordinator.async_update_config_value(CONF_KEEP_MINIMUM_FILES, 1000)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("number.test_cleanup_keep_minimum_files")
+    assert state is not None, "keep_minimum_files entity should still exist"
+    assert float(state.state) == 1000, "State should reflect updated coordinator config"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (0, 0),
+        (10000, 10000),
+        (100, 100),
+        (5000, 5000),
+    ],
+)
+async def test_number_keep_minimum_files_boundary_values(
+    hass: HomeAssistant, init_integration, value, expected
+):
+    """Test boundary values are accepted."""
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: "number.test_cleanup_keep_minimum_files", ATTR_VALUE: value},
+        blocking=True,
+    )
+
+    state = hass.states.get("number.test_cleanup_keep_minimum_files")
+    assert float(state.state) == expected, f"Should accept value {expected}"
+
+
+# ==================== MAX_FILES_IN_FOLDER NUMBER ENTITY TESTS ====================
+
+
+async def test_number_max_files_in_folder_setup(hass: HomeAssistant, init_integration):
+    """Test max_files_in_folder number entity is created during platform setup."""
+    state = hass.states.get("number.test_cleanup_max_files_in_folder")
+    assert state is not None, "max_files_in_folder number entity should exist"
+
+
+async def test_number_max_files_in_folder_initial_value(
+    hass: HomeAssistant, init_integration
+):
+    """Test initial value matches coordinator config."""
+    coordinator = init_integration.runtime_data
+
+    state = hass.states.get("number.test_cleanup_max_files_in_folder")
+    assert state is not None, "max_files_in_folder entity should exist"
+
+    assert (
+        float(state.state) == coordinator.max_files_in_folder
+    ), "Initial value should match coordinator"
+
+
+async def test_number_max_files_in_folder_set_value(
+    hass: HomeAssistant, init_integration
+):
+    """Test setting value via number.set_value service."""
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: "number.test_cleanup_max_files_in_folder",
+            ATTR_VALUE: 50000,
+        },
+        blocking=True,
+    )
+
+    state = hass.states.get("number.test_cleanup_max_files_in_folder")
+    assert state is not None, "Entity should still exist after update"
+    assert float(state.state) == 50000, "State should be updated to 50000"
+
+
+async def test_number_max_files_in_folder_set_value_updates_config(
+    hass: HomeAssistant, init_integration
+):
+    """Test config is persisted via async_update_config_value."""
+    coordinator = init_integration.runtime_data
+
+    with (
+        patch.object(coordinator, "async_update_config_value") as mock_update_config,
+        patch.object(hass.config_entries, "async_update_entry"),
+    ):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: "number.test_cleanup_max_files_in_folder",
+                ATTR_VALUE: 100000,
+            },
+            blocking=True,
+        )
+
+        mock_update_config.assert_called_once_with(CONF_MAX_FILES_IN_FOLDER, 100000)
+
+
+async def test_number_max_files_in_folder_set_value_triggers_scan(
+    hass: HomeAssistant, init_integration
+):
+    """Test coordinator refresh is triggered."""
+    coordinator = init_integration.runtime_data
+
+    initial_last_scan = coordinator.last_scan
+
+    with patch.object(hass.config_entries, "async_update_entry"):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: "number.test_cleanup_max_files_in_folder",
+                ATTR_VALUE: 75000,
+            },
+            blocking=True,
+        )
+
+    assert (
+        coordinator.last_scan != initial_last_scan
+    ), "Coordinator should have refreshed"
+
+
+async def test_number_max_files_in_folder_min_max_validation(
+    hass: HomeAssistant, init_integration
+):
+    """Test min (0) and max (1000000) boundaries are enforced."""
+    registry = er.async_get(hass)
+
+    entry = registry.async_get("number.test_cleanup_max_files_in_folder")
+    assert entry is not None, "max_files_in_folder entity should exist in registry"
+
+    state = hass.states.get("number.test_cleanup_max_files_in_folder")
+    assert state is not None, "max_files_in_folder entity state should exist"
+
+    assert state.attributes.get("min") == 0, "Min value should be 0"
+    assert state.attributes.get("max") == 1000000, "Max value should be 1000000"
+    assert state.attributes.get("step") == 1, "Step value should be 1"
+
+
+async def test_number_max_files_in_folder_attributes(
+    hass: HomeAssistant, init_integration
+):
+    """Test max_files_in_folder entity attributes and configuration."""
+    registry = er.async_get(hass)
+
+    entry = registry.async_get("number.test_cleanup_max_files_in_folder")
+    assert entry is not None, "max_files_in_folder entity should exist in registry"
+    assert (
+        entry.unique_id == f"{init_integration.entry_id}_max_files_in_folder"
+    ), "Should have correct unique_id format"
+    assert (
+        entry.entity_category == EntityCategory.CONFIG
+    ), "Should have CONFIG entity category"
+
+    state = hass.states.get("number.test_cleanup_max_files_in_folder")
+    assert state is not None, "max_files_in_folder entity state should exist"
+    assert (
+        state.attributes.get("unit_of_measurement") == "files"
+    ), "Should have 'files' unit"
+    assert (
+        state.attributes.get("mode") == "box"
+    ), "Should have 'box' mode for text input"
+
+
+async def test_number_max_files_in_folder_device_info(
+    hass: HomeAssistant, init_integration
+):
+    """Test that max_files_in_folder entity is linked to the correct device."""
+    registry = er.async_get(hass)
+
+    entry = registry.async_get("number.test_cleanup_max_files_in_folder")
+    assert entry is not None, "max_files_in_folder entity should exist"
+    assert entry.device_id is not None, "Should be linked to device"
+
+    try:
+        device_registry = hass.helpers.device_registry.async_get()
+    except TypeError:
+        device_registry = hass.helpers.device_registry.async_get(hass)
+
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, init_integration.entry_id)}
+    )
+    assert device is not None, "Device should exist"
+    assert (
+        DOMAIN,
+        init_integration.entry_id,
+    ) in device.identifiers, "Device should have correct identifiers"
+
+
+async def test_number_max_files_in_folder_unique_id_stable(
+    hass: HomeAssistant, init_integration
+):
+    """Test that max_files_in_folder entity unique ID remains stable."""
+    registry = er.async_get(hass)
+    entry_id = init_integration.entry_id
+
+    entity_id = registry.async_get_entity_id(
+        NUMBER_DOMAIN, DOMAIN, f"{entry_id}_max_files_in_folder"
+    )
+    assert (
+        entity_id is not None
+    ), "max_files_in_folder entity should be found by unique_id"
+    assert (
+        entity_id == "number.test_cleanup_max_files_in_folder"
+    ), "Should have correct entity_id"
+
+
+async def test_number_max_files_in_folder_updates_from_coordinator(
+    hass: HomeAssistant, init_integration
+):
+    """Test that max_files_in_folder entity reflects coordinator config changes."""
+    coordinator = init_integration.runtime_data
+
+    await coordinator.async_update_config_value(CONF_MAX_FILES_IN_FOLDER, 250000)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("number.test_cleanup_max_files_in_folder")
+    assert state is not None, "max_files_in_folder entity should still exist"
+    assert (
+        float(state.state) == 250000
+    ), "State should reflect updated coordinator config"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (0, 0),
+        (1000000, 1000000),
+        (10000, 10000),
+        (500000, 500000),
+    ],
+)
+async def test_number_max_files_in_folder_boundary_values(
+    hass: HomeAssistant, init_integration, value, expected
+):
+    """Test boundary values are accepted."""
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: "number.test_cleanup_max_files_in_folder", ATTR_VALUE: value},
+        blocking=True,
+    )
+
+    state = hass.states.get("number.test_cleanup_max_files_in_folder")
+    assert float(state.state) == expected, f"Should accept value {expected}"
+
+
+async def test_number_max_files_in_folder_zero_unlimited(
+    hass: HomeAssistant, init_integration
+):
+    """Test that 0 means unlimited."""
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: "number.test_cleanup_max_files_in_folder", ATTR_VALUE: 0},
+        blocking=True,
+    )
+
+    coordinator = init_integration.runtime_data
+    state = hass.states.get("number.test_cleanup_max_files_in_folder")
+
+    assert float(state.state) == 0, "State should be 0"
+    assert (
+        coordinator.max_files_in_folder == 0
+    ), "Coordinator should store 0 (unlimited)"
+
+
+# ==================== COMBINED TESTS FOR ALL NUMBER ENTITIES ====================
+
+
+async def test_number_all_four_entities_exist(hass: HomeAssistant, init_integration):
+    """Test all 4 number entities are created."""
+    entities = [
+        "number.test_cleanup_retention_days",
+        "number.test_cleanup_max_deletes",
+        "number.test_cleanup_keep_minimum_files",
+        "number.test_cleanup_max_files_in_folder",
+    ]
+
+    for entity_id in entities:
+        state = hass.states.get(entity_id)
+        assert state is not None, f"Entity {entity_id} should exist"
+
+
+async def test_number_all_have_config_category(hass: HomeAssistant, init_integration):
+    """Test all number entities have CONFIG category."""
+    ent_reg = er.async_get(hass)
+
+    entities = [
+        "number.test_cleanup_retention_days",
+        "number.test_cleanup_max_deletes",
+        "number.test_cleanup_keep_minimum_files",
+        "number.test_cleanup_max_files_in_folder",
+    ]
+
+    for entity_id in entities:
+        entity_entry = ent_reg.async_get(entity_id)
+        assert entity_entry is not None, f"Entity {entity_id} should be registered"
+        assert (
+            entity_entry.entity_category == EntityCategory.CONFIG
+        ), f"Entity {entity_id} should have CONFIG category"

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -950,3 +950,200 @@ async def test_number_all_have_config_category(hass: HomeAssistant, init_integra
         assert (
             entity_entry.entity_category == EntityCategory.CONFIG
         ), f"Entity {entity_id} should have CONFIG category"
+
+
+# ==================== INTEGER TYPE VERIFICATION TESTS (TDD) ====================
+
+
+async def test_number_native_value_returns_int_not_float(
+    hass: HomeAssistant, init_integration
+):
+    """Test native_value property returns int type, not float."""
+    entity_keys = [
+        ("retention_days", "number.test_cleanup_retention_days"),
+        ("max_deletes", "number.test_cleanup_max_deletes"),
+        ("keep_minimum_files", "number.test_cleanup_keep_minimum_files"),
+        ("max_files_in_folder", "number.test_cleanup_max_files_in_folder"),
+    ]
+
+    for _key, entity_id in entity_keys:
+        entity = hass.data[NUMBER_DOMAIN].get_entity(entity_id)
+        assert entity is not None, f"Entity {entity_id} should exist"
+
+        native_value = entity.native_value
+        assert isinstance(
+            native_value, int
+        ), f"{entity_id} native_value should be int type, got {type(native_value)}"
+        assert not isinstance(
+            native_value, float
+        ), f"{entity_id} native_value should not be float type"
+
+
+async def test_number_retention_days_returns_int(hass: HomeAssistant, init_integration):
+    """Test retention_days number entity returns integer."""
+    entity = hass.data[NUMBER_DOMAIN].get_entity("number.test_cleanup_retention_days")
+    assert entity is not None, "retention_days entity should exist"
+
+    value = entity.native_value
+    assert isinstance(value, int), f"native_value should be int, got {type(value)}"
+    assert not isinstance(value, float), "native_value should not be float"
+    assert value == 7, "Should match initial retention_days config"
+
+
+async def test_number_max_deletes_returns_int(hass: HomeAssistant, init_integration):
+    """Test max_deletes number entity returns integer."""
+    entity = hass.data[NUMBER_DOMAIN].get_entity("number.test_cleanup_max_deletes")
+    assert entity is not None, "max_deletes entity should exist"
+
+    value = entity.native_value
+    assert isinstance(value, int), f"native_value should be int, got {type(value)}"
+    assert not isinstance(value, float), "native_value should not be float"
+    assert value == 100, "Should match initial max_deletes config"
+
+
+async def test_number_keep_minimum_files_returns_int(
+    hass: HomeAssistant, init_integration
+):
+    """Test keep_minimum_files number entity returns integer."""
+    entity = hass.data[NUMBER_DOMAIN].get_entity(
+        "number.test_cleanup_keep_minimum_files"
+    )
+    assert entity is not None, "keep_minimum_files entity should exist"
+
+    value = entity.native_value
+    assert isinstance(value, int), f"native_value should be int, got {type(value)}"
+    assert not isinstance(value, float), "native_value should not be float"
+    assert value == 5, "Should match initial keep_minimum_files config"
+
+
+async def test_number_max_files_in_folder_returns_int(
+    hass: HomeAssistant, init_integration
+):
+    """Test max_files_in_folder number entity returns integer."""
+    entity = hass.data[NUMBER_DOMAIN].get_entity(
+        "number.test_cleanup_max_files_in_folder"
+    )
+    assert entity is not None, "max_files_in_folder entity should exist"
+
+    value = entity.native_value
+    assert isinstance(value, int), f"native_value should be int, got {type(value)}"
+    assert not isinstance(value, float), "native_value should not be float"
+    assert value == 50, "Should match initial max_files_in_folder config"
+
+
+@pytest.mark.parametrize(
+    ("entity_key", "entity_id", "new_value"),
+    [
+        ("retention_days", "number.test_cleanup_retention_days", 14),
+        ("max_deletes", "number.test_cleanup_max_deletes", 500),
+        ("keep_minimum_files", "number.test_cleanup_keep_minimum_files", 100),
+        ("max_files_in_folder", "number.test_cleanup_max_files_in_folder", 75),
+    ],
+)
+async def test_number_set_value_maintains_int_type(
+    hass: HomeAssistant, init_integration, entity_key, entity_id, new_value
+):
+    """Test that setting values maintains int type after update."""
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: new_value},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    entity = hass.data[NUMBER_DOMAIN].get_entity(entity_id)
+    value = entity.native_value
+
+    assert isinstance(
+        value, int
+    ), f"After update, {entity_id} native_value should be int, got {type(value)}"
+    assert not isinstance(
+        value, float
+    ), f"After update, {entity_id} native_value should not be float"
+    assert value == new_value, f"Value should be {new_value}"
+
+
+async def test_number_int_type_with_boundary_values(
+    hass: HomeAssistant, init_integration
+):
+    """Test integer type is maintained at boundary values."""
+    test_cases = [
+        ("number.test_cleanup_retention_days", 1),
+        ("number.test_cleanup_retention_days", 3650),
+        ("number.test_cleanup_max_deletes", 1),
+        ("number.test_cleanup_max_deletes", 10000),
+        ("number.test_cleanup_keep_minimum_files", 0),
+        ("number.test_cleanup_keep_minimum_files", 10000),
+        ("number.test_cleanup_max_files_in_folder", 0),
+        ("number.test_cleanup_max_files_in_folder", 1000000),
+    ]
+
+    for entity_id, boundary_value in test_cases:
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: boundary_value},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        entity = hass.data[NUMBER_DOMAIN].get_entity(entity_id)
+        value = entity.native_value
+
+        assert isinstance(
+            value, int
+        ), f"{entity_id} at boundary {boundary_value} should be int, got {type(value)}"
+        assert not isinstance(
+            value, float
+        ), f"{entity_id} at boundary {boundary_value} should not be float"
+        assert (
+            value == boundary_value
+        ), f"{entity_id} should equal boundary value {boundary_value}"
+
+
+async def test_number_type_annotation_matches_implementation(
+    hass: HomeAssistant, init_integration
+):
+    """Test that native_value type annotation matches actual return type."""
+    import inspect
+
+    from custom_components.retention_cleaner.number import (
+        RetentionCleanerNumberEntity,
+    )
+
+    entity = hass.data[NUMBER_DOMAIN].get_entity("number.test_cleanup_retention_days")
+    assert entity is not None, "Entity should exist"
+
+    annotations = inspect.get_annotations(
+        RetentionCleanerNumberEntity.native_value.fget
+    )
+    return_type = annotations.get("return")
+
+    actual_value = entity.native_value
+    assert isinstance(
+        actual_value, int
+    ), f"Actual value should be int, got {type(actual_value)}"
+
+    if return_type is not None:
+        assert (
+            return_type is int or return_type == "int"
+        ), f"Type annotation should be int, got {return_type}"
+
+
+async def test_number_coordinator_values_are_int(hass: HomeAssistant, init_integration):
+    """Test that coordinator stores values as int to ensure consistency."""
+    coordinator = init_integration.runtime_data
+
+    assert isinstance(
+        coordinator.retention_days, int
+    ), "Coordinator retention_days should be int"
+    assert isinstance(
+        coordinator.max_deletes, int
+    ), "Coordinator max_deletes should be int"
+    assert isinstance(
+        coordinator.keep_minimum_files, int
+    ), "Coordinator keep_minimum_files should be int"
+    assert isinstance(
+        coordinator.max_files_in_folder, int
+    ), "Coordinator max_files_in_folder should be int"

--- a/tests/test_remove_empty_folders.py
+++ b/tests/test_remove_empty_folders.py
@@ -608,3 +608,38 @@ async def test_logs_at_debug_level(
         assert has_removal_log, "Should log directory removal at DEBUG level"
     finally:
         await coordinator.async_shutdown()
+
+
+async def test_remove_empty_folders_property_test_override(
+    hass: HomeAssistant, mock_remove_empty_config, tmp_path
+):
+    """Test that _test_remove_empty_folders override works correctly.
+
+    This covers the defensive code path in remove_empty_folders property
+    that checks for a test override attribute before checking the config.
+    """
+    media_dir = tmp_path / "media"
+    media_dir.mkdir(parents=True)
+    empty_dir = media_dir / "empty_folder"
+    empty_dir.mkdir()
+
+    entry = mock_remove_empty_config(
+        base_path=str(media_dir), remove_empty=False, dry_run=False
+    )
+    coordinator = RetentionCleanerCoordinator(hass, entry)
+
+    try:
+        assert not coordinator.remove_empty_folders, "Config should disable feature"
+
+        coordinator._test_remove_empty_folders = True
+        assert coordinator.remove_empty_folders, "Test override should enable feature"
+
+        coordinator._test_remove_empty_folders = False
+        assert (
+            not coordinator.remove_empty_folders
+        ), "Test override should disable feature"
+
+        delattr(coordinator, "_test_remove_empty_folders")
+        assert not coordinator.remove_empty_folders, "Should fall back to config"
+    finally:
+        await coordinator.async_shutdown()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -29,13 +29,13 @@ async def test_sensor_attributes(hass: HomeAssistant, init_integration):
     assert entry is not None
     assert entry.unique_id == f"{init_integration.entry_id}_total_files"
 
-    entry = registry.async_get("sensor.test_cleanup_deleted_bytes_last_cleanup")
+    entry = registry.async_get("sensor.test_cleanup_deleted_size_last_cleanup")
     assert entry is not None
     assert entry.unique_id == f"{init_integration.entry_id}_deleted_bytes_last_run"
-    state = hass.states.get("sensor.test_cleanup_deleted_bytes_last_cleanup")
+    state = hass.states.get("sensor.test_cleanup_deleted_size_last_cleanup")
     assert state is not None
     assert state.attributes.get("device_class") == SensorDeviceClass.DATA_SIZE
-    assert state.attributes.get("unit_of_measurement") == UnitOfInformation.BYTES
+    assert state.attributes.get("unit_of_measurement") == UnitOfInformation.MEGABYTES
 
     entry = registry.async_get("sensor.test_cleanup_last_scan")
     assert entry is not None
@@ -72,8 +72,10 @@ async def test_sensor_updates_from_coordinator(hass: HomeAssistant, init_integra
     state = hass.states.get("sensor.test_cleanup_deleted_last_cleanup")
     assert state.state == "10"
 
-    state = hass.states.get("sensor.test_cleanup_deleted_bytes_last_cleanup")
-    assert state.state == "102400"
+    state = hass.states.get("sensor.test_cleanup_deleted_size_last_cleanup")
+    assert (
+        state.state == "0.1024"
+    )  # 102400 bytes = 0.1024 MB (using SI units: 1 MB = 1000000 bytes)
 
     state = hass.states.get("sensor.test_cleanup_last_scan")
     assert state.state == "2024-01-01T12:00:00+00:00"  # ISO format with UTC timezone
@@ -193,14 +195,16 @@ async def test_sensor_unique_ids_stable(hass: HomeAssistant, init_integration):
         "older_than_retention": f"{entry_id}_older_than_retention",
         "deleted_last_run": f"{entry_id}_deleted_last_run",
         "deleted_bytes_last_run": f"{entry_id}_deleted_bytes_last_run",
+        "total_folder_size_bytes": f"{entry_id}_total_folder_size_bytes",
+        "older_than_retention_size_bytes": f"{entry_id}_older_than_retention_size_bytes",
         "last_scan": f"{entry_id}_last_scan",
         "last_cleanup": f"{entry_id}_last_cleanup",
         "last_scan_duration_ms": f"{entry_id}_last_scan_duration_ms",
         "last_cleanup_duration_ms": f"{entry_id}_last_cleanup_duration_ms",
+        "base_path": f"{entry_id}_base_path",
     }
 
     for sensor_type, expected_unique_id in expected_sensors.items():
-        # Find entity by unique_id
         entity = registry.async_get_entity_id("sensor", DOMAIN, expected_unique_id)
         assert entity is not None, f"Sensor {sensor_type} not found"
 
@@ -397,7 +401,7 @@ async def test_total_folder_size_bytes_sensor_exists_in_registry(
     """Test total_folder_size_bytes sensor is created in entity registry."""
     registry = er.async_get(hass)
 
-    entry = registry.async_get("sensor.test_cleanup_total_folder_size_bytes")
+    entry = registry.async_get("sensor.test_cleanup_total_folder_size")
     assert entry is not None, "total_folder_size_bytes sensor should exist"
     assert (
         entry.unique_id == f"{init_integration.entry_id}_total_folder_size_bytes"
@@ -410,7 +414,7 @@ async def test_older_than_retention_size_bytes_sensor_exists_in_registry(
     """Test older_than_retention_size_bytes sensor is created in entity registry."""
     registry = er.async_get(hass)
 
-    entry = registry.async_get("sensor.test_cleanup_older_than_retention_size_bytes")
+    entry = registry.async_get("sensor.test_cleanup_older_than_retention_size")
     assert entry is not None, "older_than_retention_size_bytes sensor should exist"
     assert (
         entry.unique_id
@@ -422,13 +426,13 @@ async def test_size_sensors_have_correct_device_class(
     hass: HomeAssistant, init_integration
 ):
     """Test size byte sensors have DATA_SIZE device class."""
-    state_total = hass.states.get("sensor.test_cleanup_total_folder_size_bytes")
+    state_total = hass.states.get("sensor.test_cleanup_total_folder_size")
     assert state_total is not None, "total_folder_size_bytes state should exist"
     assert (
         state_total.attributes.get("device_class") == SensorDeviceClass.DATA_SIZE
     ), "Should have DATA_SIZE device class"
 
-    state_old = hass.states.get("sensor.test_cleanup_older_than_retention_size_bytes")
+    state_old = hass.states.get("sensor.test_cleanup_older_than_retention_size")
     assert state_old is not None, "older_than_retention_size_bytes state should exist"
     assert (
         state_old.attributes.get("device_class") == SensorDeviceClass.DATA_SIZE
@@ -436,31 +440,31 @@ async def test_size_sensors_have_correct_device_class(
 
 
 async def test_size_sensors_have_correct_unit(hass: HomeAssistant, init_integration):
-    """Test size byte sensors have BYTES unit."""
-    state_total = hass.states.get("sensor.test_cleanup_total_folder_size_bytes")
+    """Test size byte sensors have MEGABYTES unit."""
+    state_total = hass.states.get("sensor.test_cleanup_total_folder_size")
     assert state_total is not None, "total_folder_size_bytes state should exist"
     assert (
-        state_total.attributes.get("unit_of_measurement") == UnitOfInformation.BYTES
-    ), "Should have BYTES unit"
+        state_total.attributes.get("unit_of_measurement") == UnitOfInformation.MEGABYTES
+    ), "Should have MEGABYTES unit"
 
-    state_old = hass.states.get("sensor.test_cleanup_older_than_retention_size_bytes")
+    state_old = hass.states.get("sensor.test_cleanup_older_than_retention_size")
     assert state_old is not None, "older_than_retention_size_bytes state should exist"
     assert (
-        state_old.attributes.get("unit_of_measurement") == UnitOfInformation.BYTES
-    ), "Should have BYTES unit"
+        state_old.attributes.get("unit_of_measurement") == UnitOfInformation.MEGABYTES
+    ), "Should have MEGABYTES unit"
 
 
 async def test_size_sensors_have_correct_state_class(
     hass: HomeAssistant, init_integration
 ):
     """Test size byte sensors have MEASUREMENT state class."""
-    state_total = hass.states.get("sensor.test_cleanup_total_folder_size_bytes")
+    state_total = hass.states.get("sensor.test_cleanup_total_folder_size")
     assert state_total is not None, "total_folder_size_bytes state should exist"
     assert (
         state_total.attributes.get("state_class") == SensorStateClass.MEASUREMENT
     ), "Should have MEASUREMENT state class"
 
-    state_old = hass.states.get("sensor.test_cleanup_older_than_retention_size_bytes")
+    state_old = hass.states.get("sensor.test_cleanup_older_than_retention_size")
     assert state_old is not None, "older_than_retention_size_bytes state should exist"
     assert (
         state_old.attributes.get("state_class") == SensorStateClass.MEASUREMENT
@@ -491,11 +495,11 @@ async def test_size_sensors_update_from_coordinator_data(
     coordinator.async_set_updated_data(coordinator.data)
     await hass.async_block_till_done()
 
-    state_total = hass.states.get("sensor.test_cleanup_total_folder_size_bytes")
-    assert state_total.state == "2097152", "Should display total folder size in bytes"
+    state_total = hass.states.get("sensor.test_cleanup_total_folder_size")
+    assert state_total.state == "2.097152", "Should display total folder size in MB"
 
-    state_old = hass.states.get("sensor.test_cleanup_older_than_retention_size_bytes")
-    assert state_old.state == "1048576", "Should display old files size in bytes"
+    state_old = hass.states.get("sensor.test_cleanup_older_than_retention_size")
+    assert state_old.state == "1.048576", "Should display old files size in MB"
 
 
 async def test_size_sensors_handle_missing_data(hass: HomeAssistant, init_integration):
@@ -509,13 +513,13 @@ async def test_size_sensors_handle_missing_data(hass: HomeAssistant, init_integr
     coordinator.async_set_updated_data(coordinator.data)
     await hass.async_block_till_done()
 
-    state_total = hass.states.get("sensor.test_cleanup_total_folder_size_bytes")
+    state_total = hass.states.get("sensor.test_cleanup_total_folder_size")
     assert state_total.state in [
         "0",
         "unknown",
     ], "Should have safe default for missing total_folder_size_bytes"
 
-    state_old = hass.states.get("sensor.test_cleanup_older_than_retention_size_bytes")
+    state_old = hass.states.get("sensor.test_cleanup_older_than_retention_size")
     assert state_old.state in [
         "0",
         "unknown",
@@ -528,13 +532,11 @@ async def test_size_sensors_linked_to_device(hass: HomeAssistant, init_integrati
 
     registry = er.async_get(hass)
 
-    entry_total = registry.async_get("sensor.test_cleanup_total_folder_size_bytes")
+    entry_total = registry.async_get("sensor.test_cleanup_total_folder_size")
     assert entry_total is not None, "total_folder_size_bytes entry should exist"
     assert entry_total.device_id is not None, "Should be linked to device"
 
-    entry_old = registry.async_get(
-        "sensor.test_cleanup_older_than_retention_size_bytes"
-    )
+    entry_old = registry.async_get("sensor.test_cleanup_older_than_retention_size")
     assert entry_old is not None, "older_than_retention_size_bytes entry should exist"
     assert entry_old.device_id is not None, "Should be linked to device"
 
@@ -549,3 +551,195 @@ async def test_size_sensors_linked_to_device(hass: HomeAssistant, init_integrati
     assert device is not None, "Device should exist"
     assert entry_total.device_id == device.id, "Should link to same device"
     assert entry_old.device_id == device.id, "Should link to same device"
+
+
+# ============================================================================
+# PHASE 6: CONFIG SENSORS - BASE_PATH SENSOR
+# ============================================================================
+
+
+async def test_base_path_config_sensor(hass: HomeAssistant, init_integration):
+    """Test base_path sensor exists and has correct value."""
+    state = hass.states.get("sensor.test_cleanup_base_path")
+    assert state is not None, "base_path CONFIG sensor should exist"
+    assert state.state == "/media/test", "Should display base_path from config"
+
+
+async def test_base_path_sensor_category_config(hass: HomeAssistant, init_integration):
+    """Test base_path sensor has EntityCategory.DIAGNOSTIC."""
+    registry = er.async_get(hass)
+
+    entry = registry.async_get("sensor.test_cleanup_base_path")
+    assert entry is not None, "base_path sensor should exist in registry"
+    assert (
+        entry.entity_category == EntityCategory.DIAGNOSTIC
+    ), "Should have DIAGNOSTIC category"
+
+
+async def test_base_path_sensor_unique_id(hass: HomeAssistant, init_integration):
+    """Test base_path sensor has correct unique_id format."""
+    registry = er.async_get(hass)
+
+    entry = registry.async_get("sensor.test_cleanup_base_path")
+    assert entry is not None, "base_path sensor should exist in registry"
+    assert (
+        entry.unique_id == f"{init_integration.entry_id}_base_path"
+    ), "Should have correct unique_id format"
+
+
+async def test_base_path_sensor_linked_to_device(hass: HomeAssistant, init_integration):
+    """Test base_path sensor is linked to the correct device."""
+    registry = er.async_get(hass)
+
+    entry = registry.async_get("sensor.test_cleanup_base_path")
+    assert entry is not None, "base_path sensor should exist"
+    assert entry.device_id is not None, "Should be linked to device"
+
+    try:
+        device_registry = hass.helpers.device_registry.async_get()
+    except TypeError:
+        device_registry = hass.helpers.device_registry.async_get(hass)
+
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, init_integration.entry_id)}
+    )
+    assert device is not None, "Device should exist"
+    assert entry.device_id == device.id, "Should link to same device"
+
+
+async def test_base_path_sensor_updates_from_coordinator(
+    hass: HomeAssistant, init_integration
+):
+    """Test base_path sensor always shows coordinator.base_path (from config)."""
+    coordinator = init_integration.runtime_data
+
+    # base_path sensor should always show coordinator.base_path, not from coordinator.data
+    state = hass.states.get("sensor.test_cleanup_base_path")
+    assert state.state == coordinator.base_path, "Should show coordinator.base_path"
+    assert state.state == "/media/test", "Should match config value"
+
+    # Even if we update coordinator.data with different base_path, sensor shows config value
+    coordinator.data = {
+        "base_path": "/wrong/path",  # This should be ignored
+    }
+
+    coordinator.async_set_updated_data(coordinator.data)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.test_cleanup_base_path")
+    assert state.state == "/media/test", "Should still show original config value"
+
+
+async def test_sensor_attributes_empty(hass: HomeAssistant, init_integration):
+    """Test all sensors now have empty attributes."""
+    from datetime import UTC, datetime
+
+    coordinator = init_integration.runtime_data
+
+    coordinator.data = {
+        "total_files": 100,
+        "older_than_retention": 25,
+        "deleted_last_run": 10,
+        "deleted_bytes_last_run": 102400,
+        "last_scan": datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC),
+        "last_cleanup": datetime(2024, 1, 1, 2, 0, 0, tzinfo=UTC),
+        "last_scan_duration_ms": 150,
+        "last_cleanup_duration_ms": 500,
+        "total_folder_size_bytes": 2097152,
+        "older_than_retention_size_bytes": 1048576,
+        "base_path": "/media/test",
+        "pattern": "*.jpg",
+        "retention_days": 7,
+    }
+
+    coordinator.async_set_updated_data(coordinator.data)
+    await hass.async_block_till_done()
+
+    test_sensors = [
+        "sensor.test_cleanup_total_files",
+        "sensor.test_cleanup_older_than_retention",
+        "sensor.test_cleanup_deleted_last_cleanup",
+        "sensor.test_cleanup_deleted_size_last_cleanup",
+        "sensor.test_cleanup_total_folder_size",
+        "sensor.test_cleanup_older_than_retention_size",
+        "sensor.test_cleanup_last_scan",
+        "sensor.test_cleanup_last_cleanup",
+        "sensor.test_cleanup_last_scan_duration",
+        "sensor.test_cleanup_last_cleanup_duration",
+        "sensor.test_cleanup_base_path",
+    ]
+
+    for sensor_id in test_sensors:
+        state = hass.states.get(sensor_id)
+        assert state is not None, f"Sensor {sensor_id} should exist"
+
+        attrs = state.attributes
+        assert (
+            "base_path" not in attrs
+        ), f"{sensor_id} should not have base_path attribute"
+        assert "pattern" not in attrs, f"{sensor_id} should not have pattern attribute"
+        assert (
+            "retention_days" not in attrs
+        ), f"{sensor_id} should not have retention_days attribute"
+
+
+async def test_base_path_sensor_handles_missing_data(
+    hass: HomeAssistant, init_integration
+):
+    """Test base_path sensor handles missing data gracefully."""
+    coordinator = init_integration.runtime_data
+
+    coordinator.data = {
+        "total_files": 50,
+    }
+
+    coordinator.async_set_updated_data(coordinator.data)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.test_cleanup_base_path")
+    assert state.state in [
+        "unknown",
+        "/media/test",
+    ], "Should show unknown or fallback to config value"
+
+
+async def test_base_path_sensor_has_correct_icon(hass: HomeAssistant, init_integration):
+    """Test base_path sensor has the correct folder icon."""
+    state = hass.states.get("sensor.test_cleanup_base_path")
+    assert state is not None, "base_path sensor should exist"
+    assert state.attributes.get("icon") == "mdi:folder", "Should have folder icon"
+
+
+async def test_sensor_attributes_not_restored(hass: HomeAssistant, init_integration):
+    """Test that config attributes are not restored from previous state."""
+    coordinator = init_integration.runtime_data
+
+    coordinator.data = {}
+    coordinator.async_set_updated_data(coordinator.data)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.test_cleanup_total_files")
+    assert state is not None, "total_files sensor should exist"
+
+    attrs = state.attributes
+    assert "base_path" not in attrs, "Should not restore base_path attribute"
+    assert "pattern" not in attrs, "Should not restore pattern attribute"
+    assert "retention_days" not in attrs, "Should not restore retention_days attribute"
+
+
+async def test_base_path_sensor_no_device_class(hass: HomeAssistant, init_integration):
+    """Test base_path sensor has no device class."""
+    state = hass.states.get("sensor.test_cleanup_base_path")
+    assert state is not None, "base_path sensor should exist"
+    assert (
+        state.attributes.get("device_class") is None
+    ), "CONFIG sensor should not have device class"
+
+
+async def test_base_path_sensor_no_state_class(hass: HomeAssistant, init_integration):
+    """Test base_path sensor has no state class."""
+    state = hass.states.get("sensor.test_cleanup_base_path")
+    assert state is not None, "base_path sensor should exist"
+    assert (
+        state.attributes.get("state_class") is None
+    ), "CONFIG sensor should not have state class"

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,766 @@
+"""Test retention_cleaner switch entities."""
+
+from unittest.mock import patch
+
+from homeassistant.components.switch import (
+    DOMAIN as SWITCH_DOMAIN,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.const import ATTR_ENTITY_ID, EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+import pytest
+
+from custom_components.retention_cleaner.const import (
+    CONF_DRY_RUN,
+    CONF_REMOVE_EMPTY_FOLDERS,
+    DOMAIN,
+)
+
+
+async def test_switch_dry_run_setup(hass: HomeAssistant, init_integration):
+    """Test dry_run switch entity is created during platform setup."""
+    state = hass.states.get("switch.test_cleanup_dry_run")
+    assert state is not None, "dry_run switch entity should exist"
+
+
+async def test_switch_remove_empty_folders_setup(hass: HomeAssistant, init_integration):
+    """Test remove_empty_folders switch entity is created during platform setup."""
+    state = hass.states.get("switch.test_cleanup_remove_empty_folders")
+    assert state is not None, "remove_empty_folders switch entity should exist"
+
+
+async def test_switch_both_entities_exist(hass: HomeAssistant, init_integration):
+    """Test that both switch entities are created during setup."""
+    dry_run_state = hass.states.get("switch.test_cleanup_dry_run")
+    remove_empty_state = hass.states.get("switch.test_cleanup_remove_empty_folders")
+
+    assert dry_run_state is not None, "dry_run switch should exist"
+    assert remove_empty_state is not None, "remove_empty_folders switch should exist"
+
+
+async def test_switch_dry_run_initial_state(hass: HomeAssistant, init_integration):
+    """Test initial state matches coordinator config."""
+    coordinator = init_integration.runtime_data
+
+    state = hass.states.get("switch.test_cleanup_dry_run")
+    assert state is not None, "dry_run switch entity should exist"
+
+    expected_state = "on" if coordinator.dry_run else "off"
+    assert (
+        state.state == expected_state
+    ), f"Initial state should be '{expected_state}' matching coordinator config"
+
+
+async def test_switch_remove_empty_folders_initial_state(
+    hass: HomeAssistant, init_integration
+):
+    """Test initial state matches coordinator config."""
+    coordinator = init_integration.runtime_data
+
+    state = hass.states.get("switch.test_cleanup_remove_empty_folders")
+    assert state is not None, "remove_empty_folders switch entity should exist"
+
+    expected_state = "on" if coordinator.remove_empty_folders else "off"
+    assert (
+        state.state == expected_state
+    ), f"Initial state should be '{expected_state}' matching coordinator config"
+
+
+async def test_switch_dry_run_turn_on(hass: HomeAssistant, init_integration):
+    """Test turning on updates config to True."""
+    coordinator = init_integration.runtime_data
+
+    coordinator.dry_run = False
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "switch.test_cleanup_dry_run"},
+        blocking=True,
+    )
+
+    state = hass.states.get("switch.test_cleanup_dry_run")
+    assert state is not None, "Switch entity should still exist"
+    assert state.state == "on", "State should be on"
+    assert coordinator.dry_run is True, "Coordinator dry_run should be True"
+
+
+async def test_switch_dry_run_turn_off(hass: HomeAssistant, init_integration):
+    """Test turning off updates config to False."""
+    coordinator = init_integration.runtime_data
+
+    coordinator.dry_run = True
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "switch.test_cleanup_dry_run"},
+        blocking=True,
+    )
+
+    state = hass.states.get("switch.test_cleanup_dry_run")
+    assert state is not None, "Switch entity should still exist"
+    assert state.state == "off", "State should be off"
+    assert coordinator.dry_run is False, "Coordinator dry_run should be False"
+
+
+async def test_switch_remove_empty_folders_turn_on(
+    hass: HomeAssistant, init_integration
+):
+    """Test turning on updates config to True."""
+    coordinator = init_integration.runtime_data
+
+    coordinator.remove_empty_folders = False
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "switch.test_cleanup_remove_empty_folders"},
+        blocking=True,
+    )
+
+    state = hass.states.get("switch.test_cleanup_remove_empty_folders")
+    assert state is not None, "Switch entity should still exist"
+    assert state.state == "on", "State should be on"
+    assert (
+        coordinator.remove_empty_folders is True
+    ), "Coordinator remove_empty_folders should be True"
+
+
+async def test_switch_remove_empty_folders_turn_off(
+    hass: HomeAssistant, init_integration
+):
+    """Test turning off updates config to False."""
+    coordinator = init_integration.runtime_data
+
+    coordinator.remove_empty_folders = True
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "switch.test_cleanup_remove_empty_folders"},
+        blocking=True,
+    )
+
+    state = hass.states.get("switch.test_cleanup_remove_empty_folders")
+    assert state is not None, "Switch entity should still exist"
+    assert state.state == "off", "State should be off"
+    assert (
+        coordinator.remove_empty_folders is False
+    ), "Coordinator remove_empty_folders should be False"
+
+
+async def test_switch_dry_run_persists(hass: HomeAssistant, init_integration):
+    """Test config is persisted via async_update_config_value."""
+    coordinator = init_integration.runtime_data
+
+    with (
+        patch.object(coordinator, "async_update_config_value") as mock_update_config,
+        patch.object(hass.config_entries, "async_update_entry"),
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "switch.test_cleanup_dry_run"},
+            blocking=True,
+        )
+
+        mock_update_config.assert_called_once_with(CONF_DRY_RUN, False)
+
+
+async def test_switch_remove_empty_folders_persists(
+    hass: HomeAssistant, init_integration
+):
+    """Test config is persisted via async_update_config_value."""
+    coordinator = init_integration.runtime_data
+
+    with (
+        patch.object(coordinator, "async_update_config_value") as mock_update_config,
+        patch.object(hass.config_entries, "async_update_entry"),
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.test_cleanup_remove_empty_folders"},
+            blocking=True,
+        )
+
+        mock_update_config.assert_called_once_with(CONF_REMOVE_EMPTY_FOLDERS, True)
+
+
+async def test_switch_dry_run_boolean_type_on(hass: HomeAssistant, init_integration):
+    """Test turn_on passes boolean True to coordinator."""
+    coordinator = init_integration.runtime_data
+
+    with (
+        patch.object(coordinator, "async_update_config_value") as mock_update_config,
+        patch.object(hass.config_entries, "async_update_entry"),
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.test_cleanup_dry_run"},
+            blocking=True,
+        )
+
+        args = mock_update_config.call_args[0]
+        assert args[0] == CONF_DRY_RUN, "Should update CONF_DRY_RUN"
+        assert args[1] is True, "Should pass boolean True"
+        assert isinstance(args[1], bool), "Should be boolean type, not string"
+
+
+async def test_switch_dry_run_boolean_type_off(hass: HomeAssistant, init_integration):
+    """Test turn_off passes boolean False to coordinator."""
+    coordinator = init_integration.runtime_data
+
+    with (
+        patch.object(coordinator, "async_update_config_value") as mock_update_config,
+        patch.object(hass.config_entries, "async_update_entry"),
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "switch.test_cleanup_dry_run"},
+            blocking=True,
+        )
+
+        args = mock_update_config.call_args[0]
+        assert args[0] == CONF_DRY_RUN, "Should update CONF_DRY_RUN"
+        assert args[1] is False, "Should pass boolean False"
+        assert isinstance(args[1], bool), "Should be boolean type, not string"
+
+
+async def test_switch_dry_run_attributes(hass: HomeAssistant, init_integration):
+    """Test switch entity attributes and configuration."""
+    registry = er.async_get(hass)
+
+    entry = registry.async_get("switch.test_cleanup_dry_run")
+    assert entry is not None, "Switch entity should exist in registry"
+    assert (
+        entry.unique_id == f"{init_integration.entry_id}_dry_run"
+    ), "Should have correct unique_id format"
+    assert (
+        entry.entity_category == EntityCategory.CONFIG
+    ), "Should have CONFIG entity category"
+
+    state = hass.states.get("switch.test_cleanup_dry_run")
+    assert state is not None, "Switch entity state should exist"
+    assert state.attributes.get("icon") == "mdi:test-tube", "Should have test-tube icon"
+
+
+async def test_switch_remove_empty_folders_attributes(
+    hass: HomeAssistant, init_integration
+):
+    """Test switch entity attributes and configuration."""
+    registry = er.async_get(hass)
+
+    entry = registry.async_get("switch.test_cleanup_remove_empty_folders")
+    assert entry is not None, "Switch entity should exist in registry"
+    assert (
+        entry.unique_id == f"{init_integration.entry_id}_remove_empty_folders"
+    ), "Should have correct unique_id format"
+    assert (
+        entry.entity_category == EntityCategory.CONFIG
+    ), "Should have CONFIG entity category"
+
+    state = hass.states.get("switch.test_cleanup_remove_empty_folders")
+    assert state is not None, "Switch entity state should exist"
+    assert (
+        state.attributes.get("icon") == "mdi:folder-remove"
+    ), "Should have folder-remove icon"
+
+
+async def test_switch_dry_run_device_info(hass: HomeAssistant, init_integration):
+    """Test that switch entity is linked to the correct device."""
+    registry = er.async_get(hass)
+
+    entry = registry.async_get("switch.test_cleanup_dry_run")
+    assert entry is not None, "Switch entity should exist"
+    assert entry.device_id is not None, "Should be linked to device"
+
+    try:
+        device_registry = hass.helpers.device_registry.async_get()
+    except TypeError:
+        device_registry = hass.helpers.device_registry.async_get(hass)
+
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, init_integration.entry_id)}
+    )
+    assert device is not None, "Device should exist"
+    assert device.name == "Test Cleanup", "Device should have correct name"
+    assert device.model == "Folder retention rule", "Device should have correct model"
+    assert (
+        device.manufacturer == "Retention Cleaner"
+    ), "Device should have correct manufacturer"
+    assert (
+        DOMAIN,
+        init_integration.entry_id,
+    ) in device.identifiers, "Device should have correct identifiers"
+
+
+async def test_switch_remove_empty_folders_device_info(
+    hass: HomeAssistant, init_integration
+):
+    """Test that switch entity is linked to the correct device."""
+    registry = er.async_get(hass)
+
+    entry = registry.async_get("switch.test_cleanup_remove_empty_folders")
+    assert entry is not None, "Switch entity should exist"
+    assert entry.device_id is not None, "Should be linked to device"
+
+    try:
+        device_registry = hass.helpers.device_registry.async_get()
+    except TypeError:
+        device_registry = hass.helpers.device_registry.async_get(hass)
+
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, init_integration.entry_id)}
+    )
+    assert device is not None, "Device should exist"
+
+
+async def test_switch_dry_run_unique_id_stable(hass: HomeAssistant, init_integration):
+    """Test that switch entity unique ID remains stable."""
+    registry = er.async_get(hass)
+    entry_id = init_integration.entry_id
+
+    entity_id = registry.async_get_entity_id(
+        SWITCH_DOMAIN, DOMAIN, f"{entry_id}_dry_run"
+    )
+    assert entity_id is not None, "Switch entity should be found by unique_id"
+    assert entity_id == "switch.test_cleanup_dry_run", "Should have correct entity_id"
+
+
+async def test_switch_remove_empty_folders_unique_id_stable(
+    hass: HomeAssistant, init_integration
+):
+    """Test that switch entity unique ID remains stable."""
+    registry = er.async_get(hass)
+    entry_id = init_integration.entry_id
+
+    entity_id = registry.async_get_entity_id(
+        SWITCH_DOMAIN, DOMAIN, f"{entry_id}_remove_empty_folders"
+    )
+    assert entity_id is not None, "Switch entity should be found by unique_id"
+    assert (
+        entity_id == "switch.test_cleanup_remove_empty_folders"
+    ), "Should have correct entity_id"
+
+
+async def test_switch_dry_run_updates_from_coordinator(
+    hass: HomeAssistant, init_integration
+):
+    """Test that switch entity reflects coordinator config changes."""
+    coordinator = init_integration.runtime_data
+
+    await coordinator.async_update_config_value(CONF_DRY_RUN, False)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_cleanup_dry_run")
+    assert state is not None, "Switch entity should still exist"
+    assert (
+        state.state == "off"
+    ), "State should reflect updated coordinator config (False -> off)"
+
+    await coordinator.async_update_config_value(CONF_DRY_RUN, True)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_cleanup_dry_run")
+    assert state is not None, "Switch entity should still exist"
+    assert (
+        state.state == "on"
+    ), "State should reflect updated coordinator config (True -> on)"
+
+
+async def test_switch_remove_empty_folders_updates_from_coordinator(
+    hass: HomeAssistant, init_integration
+):
+    """Test that switch entity reflects coordinator config changes."""
+    coordinator = init_integration.runtime_data
+
+    await coordinator.async_update_config_value(CONF_REMOVE_EMPTY_FOLDERS, True)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_cleanup_remove_empty_folders")
+    assert state is not None, "Switch entity should still exist"
+    assert (
+        state.state == "on"
+    ), "State should reflect updated coordinator config (True -> on)"
+
+    await coordinator.async_update_config_value(CONF_REMOVE_EMPTY_FOLDERS, False)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_cleanup_remove_empty_folders")
+    assert state is not None, "Switch entity should still exist"
+    assert (
+        state.state == "off"
+    ), "State should reflect updated coordinator config (False -> off)"
+
+
+@pytest.mark.parametrize(
+    ("initial_value", "service", "expected_bool", "expected_state"),
+    [
+        (True, SERVICE_TURN_OFF, False, "off"),
+        (False, SERVICE_TURN_ON, True, "on"),
+        (True, SERVICE_TURN_ON, True, "on"),
+        (False, SERVICE_TURN_OFF, False, "off"),
+    ],
+)
+async def test_switch_dry_run_multiple_toggles(
+    hass: HomeAssistant,
+    init_integration,
+    initial_value,
+    service,
+    expected_bool,
+    expected_state,
+):
+    """Test multiple switch toggles work correctly."""
+    coordinator = init_integration.runtime_data
+
+    coordinator.dry_run = initial_value
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: "switch.test_cleanup_dry_run"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_cleanup_dry_run")
+    assert state.state == expected_state, f"Should update to {expected_state}"
+    assert (
+        coordinator.dry_run == expected_bool
+    ), f"Coordinator should have {expected_bool}"
+
+
+@pytest.mark.parametrize(
+    ("initial_value", "service", "expected_bool", "expected_state"),
+    [
+        (True, SERVICE_TURN_OFF, False, "off"),
+        (False, SERVICE_TURN_ON, True, "on"),
+        (True, SERVICE_TURN_ON, True, "on"),
+        (False, SERVICE_TURN_OFF, False, "off"),
+    ],
+)
+async def test_switch_remove_empty_folders_multiple_toggles(
+    hass: HomeAssistant,
+    init_integration,
+    initial_value,
+    service,
+    expected_bool,
+    expected_state,
+):
+    """Test multiple switch toggles work correctly."""
+    coordinator = init_integration.runtime_data
+
+    coordinator.remove_empty_folders = initial_value
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: "switch.test_cleanup_remove_empty_folders"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_cleanup_remove_empty_folders")
+    assert state.state == expected_state, f"Should update to {expected_state}"
+    assert (
+        coordinator.remove_empty_folders == expected_bool
+    ), f"Coordinator should have {expected_bool}"
+
+
+async def test_switch_dry_run_initial_state_true(hass: HomeAssistant):
+    """Test initial state displays on when coordinator has dry_run=True."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    entry_true = MockConfigEntry(
+        domain="retention_cleaner",
+        title="Test Dry Run True",
+        data={
+            "base_path": "/media/test",
+            "pattern": "*.jpg",
+            "retention_days": 7,
+            "dry_run": True,
+            "max_deletes": 100,
+            "run_at": "02:00",
+        },
+        entry_id="test_dry_run_true_entry",
+    )
+    entry_true.add_to_hass(hass)
+
+    with (
+        patch("pathlib.Path.exists", return_value=True),
+        patch("pathlib.Path.is_dir", return_value=True),
+        patch("pathlib.Path.glob", return_value=[]),
+    ):
+        assert await hass.config_entries.async_setup(entry_true.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_dry_run_true_dry_run")
+    assert state is not None, "Switch entity should exist"
+    assert state.state == "on", "Should display on when dry_run is True"
+
+
+async def test_switch_dry_run_initial_state_false(hass: HomeAssistant):
+    """Test initial state displays off when coordinator has dry_run=False."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    entry_false = MockConfigEntry(
+        domain="retention_cleaner",
+        title="Test Dry Run False",
+        data={
+            "base_path": "/media/test",
+            "pattern": "*.jpg",
+            "retention_days": 7,
+            "dry_run": False,
+            "max_deletes": 100,
+            "run_at": "02:00",
+        },
+        entry_id="test_dry_run_false_entry",
+    )
+    entry_false.add_to_hass(hass)
+
+    with (
+        patch("pathlib.Path.exists", return_value=True),
+        patch("pathlib.Path.is_dir", return_value=True),
+        patch("pathlib.Path.glob", return_value=[]),
+    ):
+        assert await hass.config_entries.async_setup(entry_false.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_dry_run_false_dry_run")
+    assert state is not None, "Switch entity should exist"
+    assert state.state == "off", "Should display off when dry_run is False"
+
+
+async def test_switch_remove_empty_folders_initial_state_true(hass: HomeAssistant):
+    """Test initial state displays on when coordinator has remove_empty_folders=True."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    entry_true = MockConfigEntry(
+        domain="retention_cleaner",
+        title="Test Remove Empty True",
+        data={
+            "base_path": "/media/test",
+            "pattern": "*.jpg",
+            "retention_days": 7,
+            "dry_run": False,
+            "max_deletes": 100,
+            "run_at": "02:00",
+            "remove_empty_folders": True,
+        },
+        entry_id="test_remove_empty_true_entry",
+    )
+    entry_true.add_to_hass(hass)
+
+    with (
+        patch("pathlib.Path.exists", return_value=True),
+        patch("pathlib.Path.is_dir", return_value=True),
+        patch("pathlib.Path.glob", return_value=[]),
+    ):
+        assert await hass.config_entries.async_setup(entry_true.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_remove_empty_true_remove_empty_folders")
+    assert state is not None, "Switch entity should exist"
+    assert state.state == "on", "Should display on when remove_empty_folders is True"
+
+
+async def test_switch_remove_empty_folders_initial_state_false(hass: HomeAssistant):
+    """Test initial state displays off when coordinator has remove_empty_folders=False."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    entry_false = MockConfigEntry(
+        domain="retention_cleaner",
+        title="Test Remove Empty False",
+        data={
+            "base_path": "/media/test",
+            "pattern": "*.jpg",
+            "retention_days": 7,
+            "dry_run": False,
+            "max_deletes": 100,
+            "run_at": "02:00",
+            "remove_empty_folders": False,
+        },
+        entry_id="test_remove_empty_false_entry",
+    )
+    entry_false.add_to_hass(hass)
+
+    with (
+        patch("pathlib.Path.exists", return_value=True),
+        patch("pathlib.Path.is_dir", return_value=True),
+        patch("pathlib.Path.glob", return_value=[]),
+    ):
+        assert await hass.config_entries.async_setup(entry_false.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_remove_empty_false_remove_empty_folders")
+    assert state is not None, "Switch entity should exist"
+    assert state.state == "off", "Should display off when remove_empty_folders is False"
+
+
+async def test_switch_dry_run_availability(hass: HomeAssistant, init_integration):
+    """Test switch entity availability based on coordinator."""
+    coordinator = init_integration.runtime_data
+
+    state = hass.states.get("switch.test_cleanup_dry_run")
+    assert state.state != "unavailable", "Should be available when coordinator is ready"
+
+    coordinator.async_set_updated_data(None)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_cleanup_dry_run")
+    assert (
+        state.state != "unavailable"
+    ), "Switch entity should remain available even with no coordinator data"
+
+
+async def test_switch_remove_empty_folders_availability(
+    hass: HomeAssistant, init_integration
+):
+    """Test switch entity availability based on coordinator."""
+    coordinator = init_integration.runtime_data
+
+    state = hass.states.get("switch.test_cleanup_remove_empty_folders")
+    assert state.state != "unavailable", "Should be available when coordinator is ready"
+
+    coordinator.async_set_updated_data(None)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_cleanup_remove_empty_folders")
+    assert (
+        state.state != "unavailable"
+    ), "Switch entity should remain available even with no coordinator data"
+
+
+async def test_switch_dry_run_updates_trigger_no_scan(
+    hass: HomeAssistant, init_integration
+):
+    """Test that switch updates do not trigger coordinator refresh."""
+    coordinator = init_integration.runtime_data
+
+    initial_last_scan = coordinator.last_scan
+
+    with patch.object(hass.config_entries, "async_update_entry"):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "switch.test_cleanup_dry_run"},
+            blocking=True,
+        )
+
+    assert (
+        coordinator.last_scan == initial_last_scan
+    ), "Coordinator should not have refreshed for dry_run change"
+
+
+async def test_switch_remove_empty_folders_updates_trigger_no_scan(
+    hass: HomeAssistant, init_integration
+):
+    """Test that switch updates do not trigger coordinator refresh."""
+    coordinator = init_integration.runtime_data
+
+    initial_last_scan = coordinator.last_scan
+
+    with patch.object(hass.config_entries, "async_update_entry"):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.test_cleanup_remove_empty_folders"},
+            blocking=True,
+        )
+
+    assert (
+        coordinator.last_scan == initial_last_scan
+    ), "Coordinator should not have refreshed for remove_empty_folders change"
+
+
+async def test_switch_dry_run_round_trip_boolean(hass: HomeAssistant, init_integration):
+    """Test boolean round trip: True -> on display, turn_on -> True storage."""
+    coordinator = init_integration.runtime_data
+
+    coordinator.dry_run = True
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_cleanup_dry_run")
+    assert state.state == "on", "True should display as on"
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "switch.test_cleanup_dry_run"},
+        blocking=True,
+    )
+
+    assert coordinator.dry_run is True, "turn_on should store as True boolean"
+    assert isinstance(coordinator.dry_run, bool), "Should remain boolean type"
+
+
+async def test_switch_remove_empty_folders_round_trip_boolean(
+    hass: HomeAssistant, init_integration
+):
+    """Test boolean round trip: False -> off display, turn_off -> False storage."""
+    coordinator = init_integration.runtime_data
+
+    coordinator.remove_empty_folders = False
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.test_cleanup_remove_empty_folders")
+    assert state.state == "off", "False should display as off"
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "switch.test_cleanup_remove_empty_folders"},
+        blocking=True,
+    )
+
+    assert (
+        coordinator.remove_empty_folders is False
+    ), "turn_off should store as False boolean"
+    assert isinstance(
+        coordinator.remove_empty_folders, bool
+    ), "Should remain boolean type"
+
+
+async def test_switch_dry_run_friendly_name(hass: HomeAssistant, init_integration):
+    """Test switch entity has correct friendly name."""
+    state = hass.states.get("switch.test_cleanup_dry_run")
+    assert state is not None, "Switch entity should exist"
+    assert (
+        state.attributes.get("friendly_name") == "Test Cleanup Dry run"
+    ), "Should have correct friendly name"
+
+
+async def test_switch_remove_empty_folders_friendly_name(
+    hass: HomeAssistant, init_integration
+):
+    """Test switch entity has correct friendly name."""
+    state = hass.states.get("switch.test_cleanup_remove_empty_folders")
+    assert state is not None, "Switch entity should exist"
+    assert (
+        state.attributes.get("friendly_name")
+        == "Test Cleanup Remove empty folders after cleanup"
+    ), "Should have correct friendly name"
+
+
+async def test_switch_dry_run_no_options_attribute(
+    hass: HomeAssistant, init_integration
+):
+    """Test switch entity does not have options attribute."""
+    state = hass.states.get("switch.test_cleanup_dry_run")
+    assert state is not None, "Switch entity should exist"
+    assert "options" not in state.attributes, "Switch should not have options attribute"
+
+
+async def test_switch_remove_empty_folders_no_options_attribute(
+    hass: HomeAssistant, init_integration
+):
+    """Test switch entity does not have options attribute."""
+    state = hass.states.get("switch.test_cleanup_remove_empty_folders")
+    assert state is not None, "Switch entity should exist"
+    assert "options" not in state.attributes, "Switch should not have options attribute"

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,0 +1,787 @@
+"""Test retention_cleaner text entities."""
+
+from unittest.mock import patch
+
+from homeassistant.components.text import (
+    ATTR_VALUE,
+    DOMAIN as TEXT_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.const import ATTR_ENTITY_ID, EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import entity_registry as er
+import pytest
+
+from custom_components.retention_cleaner.const import (
+    CONF_EXCEPT_EXTENSIONS,
+    CONF_ONLY_EXTENSIONS,
+    CONF_PATTERN,
+    DOMAIN,
+)
+from tests.conftest import (
+    TEST_DANGEROUS_PATTERN_ALL,
+    TEST_DANGEROUS_PATTERN_STAR,
+    TEST_EXTENSION_NO_DOT,
+    TEST_EXTENSION_WITH_PATH,
+    TEST_EXTENSION_WITH_WILDCARD,
+    TEST_VALID_EXTENSIONS_EXCEPT,
+    TEST_VALID_EXTENSIONS_ONLY,
+    TEST_VALID_PATTERN,
+)
+
+
+async def test_text_entity_setup(hass: HomeAssistant, init_integration):
+    """Test all 3 text entities are created during platform setup."""
+    state = hass.states.get("text.test_cleanup_pattern")
+    assert state is not None, "pattern text entity should exist"
+
+    state = hass.states.get("text.test_cleanup_only_extensions")
+    assert state is not None, "only_extensions text entity should exist"
+
+    state = hass.states.get("text.test_cleanup_except_extensions")
+    assert state is not None, "except_extensions text entity should exist"
+
+
+async def test_text_entity_initial_values(hass: HomeAssistant, init_integration):
+    """Test initial values match coordinator config."""
+    coordinator = init_integration.runtime_data
+
+    state = hass.states.get("text.test_cleanup_pattern")
+    assert state is not None, "pattern text entity should exist"
+    assert (
+        state.state == coordinator.pattern
+    ), "Initial pattern should match coordinator"
+
+    state = hass.states.get("text.test_cleanup_only_extensions")
+    assert state is not None, "only_extensions text entity should exist"
+    assert (
+        state.state == coordinator.only_extensions
+    ), "Initial only_extensions should match coordinator"
+
+    state = hass.states.get("text.test_cleanup_except_extensions")
+    assert state is not None, "except_extensions text entity should exist"
+    assert (
+        state.state == coordinator.except_extensions
+    ), "Initial except_extensions should match coordinator"
+
+
+async def test_text_entity_set_pattern(hass: HomeAssistant, init_integration):
+    """Test pattern text entity can be set."""
+    await hass.services.async_call(
+        TEXT_DOMAIN,
+        SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: "text.test_cleanup_pattern",
+            ATTR_VALUE: TEST_VALID_PATTERN,
+        },
+        blocking=True,
+    )
+
+    state = hass.states.get("text.test_cleanup_pattern")
+    assert state is not None, "Text entity should still exist"
+    assert state.state == TEST_VALID_PATTERN, "State should be updated to new pattern"
+
+
+async def test_text_entity_set_extensions(hass: HomeAssistant, mock_extension_config):
+    """Test extension text entities can be set."""
+    mock_extension_config.add_to_hass(hass)
+
+    with (
+        patch("pathlib.Path.exists", return_value=True),
+        patch("pathlib.Path.is_dir", return_value=True),
+        patch("pathlib.Path.glob", return_value=[]),
+    ):
+        assert await hass.config_entries.async_setup(mock_extension_config.entry_id)
+        await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        TEXT_DOMAIN,
+        SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: "text.test_extension_mode_only_extensions",
+            ATTR_VALUE: TEST_VALID_EXTENSIONS_ONLY,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("text.test_extension_mode_only_extensions")
+    assert state is not None, "Text entity should still exist"
+    assert (
+        state.state == TEST_VALID_EXTENSIONS_ONLY
+    ), "State should be updated to new extensions"
+
+
+async def test_text_entity_set_value_updates_config(
+    hass: HomeAssistant, init_integration
+):
+    """Test config is persisted via async_update_config_value."""
+    coordinator = init_integration.runtime_data
+
+    with (
+        patch.object(coordinator, "async_update_config_value") as mock_update_config,
+        patch.object(hass.config_entries, "async_update_entry"),
+    ):
+        await hass.services.async_call(
+            TEXT_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: "text.test_cleanup_pattern",
+                ATTR_VALUE: "**/*.mp4",
+            },
+            blocking=True,
+        )
+
+        mock_update_config.assert_called_once_with(CONF_PATTERN, "**/*.mp4")
+
+
+async def test_text_entity_set_value_triggers_scan(
+    hass: HomeAssistant, init_integration
+):
+    """Test coordinator refresh is triggered."""
+    coordinator = init_integration.runtime_data
+
+    initial_last_scan = coordinator.last_scan
+
+    with patch.object(hass.config_entries, "async_update_entry"):
+        await hass.services.async_call(
+            TEXT_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: "text.test_cleanup_pattern",
+                ATTR_VALUE: "**/*.txt",
+            },
+            blocking=True,
+        )
+
+    assert (
+        coordinator.last_scan != initial_last_scan
+    ), "Coordinator should have refreshed"
+
+
+@pytest.mark.parametrize(
+    "dangerous_pattern",
+    [TEST_DANGEROUS_PATTERN_STAR, TEST_DANGEROUS_PATTERN_ALL],
+)
+async def test_text_entity_validation_rejects_dangerous_pattern(
+    hass: HomeAssistant, init_integration, dangerous_pattern
+):
+    """Test pattern validation rejects dangerous patterns."""
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            TEXT_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: "text.test_cleanup_pattern",
+                ATTR_VALUE: dangerous_pattern,
+            },
+            blocking=True,
+        )
+
+    error_msg = str(exc_info.value).lower()
+    assert (
+        "pattern_too_broad" in error_msg
+        or "too broad" in error_msg
+        or "broad" in error_msg
+    ), f"Should reject dangerous pattern: {dangerous_pattern}"
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "invalid_value", "expected_error"),
+    [
+        (
+            "text.test_cleanup_only_extensions",
+            TEST_EXTENSION_NO_DOT,
+            "extension_must_start_with_dot",
+        ),
+        (
+            "text.test_cleanup_except_extensions",
+            TEST_EXTENSION_NO_DOT,
+            "extension_must_start_with_dot",
+        ),
+    ],
+)
+async def test_text_entity_validation_requires_dot(
+    hass: HomeAssistant, init_integration, entity_id, invalid_value, expected_error
+):
+    """Test extensions must start with dot."""
+    hass.config_entries.async_update_entry(
+        init_integration,
+        options={
+            CONF_PATTERN: "",
+            CONF_ONLY_EXTENSIONS: "",
+            CONF_EXCEPT_EXTENSIONS: "",
+        },
+    )
+    await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            TEXT_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: invalid_value},
+            blocking=True,
+        )
+
+    error_msg = str(exc_info.value).lower()
+    assert (
+        expected_error.lower() in error_msg
+        or "dot" in error_msg
+        or "start with" in error_msg
+    ), f"Should require dot for extension: {invalid_value}"
+
+
+async def test_text_entity_mutual_exclusion_pattern_extensions(
+    hass: HomeAssistant, init_integration
+):
+    """Test cannot set both pattern and extensions."""
+    hass.config_entries.async_update_entry(
+        init_integration,
+        options={
+            CONF_PATTERN: TEST_VALID_PATTERN,
+            CONF_ONLY_EXTENSIONS: "",
+            CONF_EXCEPT_EXTENSIONS: "",
+        },
+    )
+    await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            TEXT_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: "text.test_cleanup_only_extensions",
+                ATTR_VALUE: TEST_VALID_EXTENSIONS_ONLY,
+            },
+            blocking=True,
+        )
+
+    error_msg = str(exc_info.value).lower()
+    assert (
+        "cannot_combine_pattern_and_extensions" in error_msg
+        or "cannot" in error_msg
+        or "pattern" in error_msg
+        or "extension" in error_msg
+    ), "Should reject setting extensions when pattern is set"
+
+    hass.config_entries.async_update_entry(
+        init_integration,
+        options={
+            CONF_PATTERN: "",
+            CONF_ONLY_EXTENSIONS: TEST_VALID_EXTENSIONS_ONLY,
+            CONF_EXCEPT_EXTENSIONS: "",
+        },
+    )
+    await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            TEXT_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: "text.test_cleanup_pattern",
+                ATTR_VALUE: TEST_VALID_PATTERN,
+            },
+            blocking=True,
+        )
+
+    error_msg = str(exc_info.value).lower()
+    assert (
+        "cannot_combine_pattern_and_extensions" in error_msg
+        or "cannot" in error_msg
+        or "pattern" in error_msg
+        or "extension" in error_msg
+    ), "Should reject setting pattern when extensions are set"
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "wildcard_value"),
+    [
+        ("text.test_cleanup_only_extensions", TEST_EXTENSION_WITH_WILDCARD),
+        ("text.test_cleanup_except_extensions", TEST_EXTENSION_WITH_WILDCARD),
+        ("text.test_cleanup_only_extensions", ".test?"),
+        ("text.test_cleanup_except_extensions", ".file[0-9]"),
+    ],
+)
+async def test_text_entity_no_wildcards_in_extensions(
+    hass: HomeAssistant, init_integration, entity_id, wildcard_value
+):
+    """Test extensions cannot contain wildcards."""
+    hass.config_entries.async_update_entry(
+        init_integration,
+        options={
+            CONF_PATTERN: "",
+            CONF_ONLY_EXTENSIONS: "",
+            CONF_EXCEPT_EXTENSIONS: "",
+        },
+    )
+    await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            TEXT_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: wildcard_value},
+            blocking=True,
+        )
+
+    error_msg = str(exc_info.value).lower()
+    assert (
+        "extension_no_wildcards" in error_msg
+        or "wildcard" in error_msg
+        or "not allowed" in error_msg
+    ), f"Should reject wildcard in extension: {wildcard_value}"
+
+
+async def test_text_entity_attributes(hass: HomeAssistant, init_integration):
+    """Test text entity attributes and configuration."""
+    registry = er.async_get(hass)
+
+    for key, entity_suffix in [
+        (CONF_PATTERN, "pattern"),
+        (CONF_ONLY_EXTENSIONS, "only_extensions"),
+        (CONF_EXCEPT_EXTENSIONS, "except_extensions"),
+    ]:
+        entity_id = f"text.test_cleanup_{entity_suffix}"
+        entry = registry.async_get(entity_id)
+        assert entry is not None, f"{key} text entity should exist in registry"
+        assert (
+            entry.unique_id == f"{init_integration.entry_id}_{key}"
+        ), f"Should have correct unique_id format for {key}"
+        assert (
+            entry.entity_category == EntityCategory.CONFIG
+        ), f"Should have CONFIG entity category for {key}"
+
+        state = hass.states.get(entity_id)
+        assert state is not None, f"{key} text entity state should exist"
+        assert (
+            state.attributes.get("mode") == "text"
+        ), f"Should have 'text' mode for {key}"
+        assert (
+            state.attributes.get("max") == 255
+        ), f"Should have max length 255 for {key}"
+
+
+async def test_text_entity_device_info(hass: HomeAssistant, init_integration):
+    """Test that text entities are linked to the correct device."""
+    registry = er.async_get(hass)
+
+    entry = registry.async_get("text.test_cleanup_pattern")
+    assert entry is not None, "Pattern text entity should exist"
+    assert entry.device_id is not None, "Should be linked to device"
+
+    try:
+        device_registry = hass.helpers.device_registry.async_get()
+    except TypeError:
+        device_registry = hass.helpers.device_registry.async_get(hass)
+
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, init_integration.entry_id)}
+    )
+    assert device is not None, "Device should exist"
+    assert device.name == "Test Cleanup", "Device should have correct name"
+    assert device.model == "Folder retention rule", "Device should have correct model"
+    assert (
+        device.manufacturer == "Retention Cleaner"
+    ), "Device should have correct manufacturer"
+
+
+async def test_text_entity_unique_id_stable(hass: HomeAssistant, init_integration):
+    """Test that text entity unique IDs remain stable."""
+    registry = er.async_get(hass)
+    entry_id = init_integration.entry_id
+
+    for key in [CONF_PATTERN, CONF_ONLY_EXTENSIONS, CONF_EXCEPT_EXTENSIONS]:
+        entity_id = registry.async_get_entity_id(
+            TEXT_DOMAIN, DOMAIN, f"{entry_id}_{key}"
+        )
+        assert entity_id is not None, f"{key} text entity should be found by unique_id"
+
+
+async def test_text_entity_updates_from_coordinator(
+    hass: HomeAssistant, init_integration
+):
+    """Test that text entities reflect coordinator config changes."""
+    coordinator = init_integration.runtime_data
+
+    await coordinator.async_update_config_value(CONF_PATTERN, "**/*.png")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("text.test_cleanup_pattern")
+    assert state is not None, "Text entity should still exist"
+    assert state.state == "**/*.png", "State should reflect updated coordinator config"
+
+
+async def test_text_entity_empty_pattern_allowed_with_extensions(
+    hass: HomeAssistant, init_integration
+):
+    """Test empty pattern is allowed when extensions are set."""
+    hass.config_entries.async_update_entry(
+        init_integration,
+        options={
+            CONF_PATTERN: "",
+            CONF_ONLY_EXTENSIONS: TEST_VALID_EXTENSIONS_ONLY,
+            CONF_EXCEPT_EXTENSIONS: "",
+        },
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        TEXT_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: "text.test_cleanup_pattern", ATTR_VALUE: ""},
+        blocking=True,
+    )
+
+    state = hass.states.get("text.test_cleanup_pattern")
+    assert state is not None, "Text entity should still exist"
+    assert state.state == "", "Empty pattern should be allowed with extensions"
+
+
+async def test_text_entity_empty_extensions_allowed(
+    hass: HomeAssistant, init_integration
+):
+    """Test empty extensions are allowed."""
+    hass.config_entries.async_update_entry(
+        init_integration,
+        options={
+            CONF_PATTERN: TEST_VALID_PATTERN,
+            CONF_ONLY_EXTENSIONS: "",
+            CONF_EXCEPT_EXTENSIONS: "",
+        },
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        TEXT_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: "text.test_cleanup_only_extensions", ATTR_VALUE: ""},
+        blocking=True,
+    )
+
+    state = hass.states.get("text.test_cleanup_only_extensions")
+    assert state is not None, "Text entity should still exist"
+    assert state.state == "", "Empty extensions should be allowed"
+
+
+async def test_text_entity_cannot_use_both_only_and_except(
+    hass: HomeAssistant, init_integration
+):
+    """Test cannot use both only_extensions and except_extensions."""
+    hass.config_entries.async_update_entry(
+        init_integration,
+        options={
+            CONF_PATTERN: "",
+            CONF_ONLY_EXTENSIONS: TEST_VALID_EXTENSIONS_ONLY,
+            CONF_EXCEPT_EXTENSIONS: "",
+        },
+    )
+    await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            TEXT_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: "text.test_cleanup_except_extensions",
+                ATTR_VALUE: TEST_VALID_EXTENSIONS_EXCEPT,
+            },
+            blocking=True,
+        )
+
+    error_msg = str(exc_info.value).lower()
+    assert (
+        "cannot_use_both_only_and_except" in error_msg
+        or "both" in error_msg
+        or "exclusive" in error_msg
+    ), "Should reject setting except_extensions when only_extensions is set"
+
+
+async def test_text_entity_invalid_pattern_syntax(
+    hass: HomeAssistant, init_integration
+):
+    """Test pattern validation rejects invalid syntax."""
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            TEXT_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: "text.test_cleanup_pattern", ATTR_VALUE: "***"},
+            blocking=True,
+        )
+
+    error_msg = str(exc_info.value).lower()
+    assert (
+        "pattern_invalid_syntax" in error_msg
+        or "invalid" in error_msg
+        or "syntax" in error_msg
+    ), "Should reject invalid pattern syntax"
+
+
+async def test_text_entity_extension_no_path_separators(
+    hass: HomeAssistant, init_integration
+):
+    """Test extensions cannot contain path separators."""
+    hass.config_entries.async_update_entry(
+        init_integration,
+        options={
+            CONF_PATTERN: "",
+            CONF_ONLY_EXTENSIONS: "",
+            CONF_EXCEPT_EXTENSIONS: "",
+        },
+    )
+    await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            TEXT_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: "text.test_cleanup_only_extensions",
+                ATTR_VALUE: TEST_EXTENSION_WITH_PATH,
+            },
+            blocking=True,
+        )
+
+    error_msg = str(exc_info.value).lower()
+    assert (
+        "extension_no_paths" in error_msg
+        or "path" in error_msg
+        or "separator" in error_msg
+    ), "Should reject path separators in extensions"
+
+
+async def test_text_entity_multiple_extensions_validation(
+    hass: HomeAssistant, init_integration
+):
+    """Test validation works with multiple comma-separated extensions."""
+    hass.config_entries.async_update_entry(
+        init_integration,
+        options={
+            CONF_PATTERN: "",
+            CONF_ONLY_EXTENSIONS: "",
+            CONF_EXCEPT_EXTENSIONS: "",
+        },
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        TEXT_DOMAIN,
+        SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: "text.test_cleanup_only_extensions",
+            ATTR_VALUE: ".mp4,.jpg,.png,.gif",
+        },
+        blocking=True,
+    )
+
+    state = hass.states.get("text.test_cleanup_only_extensions")
+    assert state is not None, "Text entity should exist"
+    assert (
+        ".mp4" in state.state and ".jpg" in state.state
+    ), "Should accept multiple valid extensions"
+
+
+async def test_text_entity_extension_too_short(hass: HomeAssistant, init_integration):
+    """Test extensions must have at least one character after dot."""
+    hass.config_entries.async_update_entry(
+        init_integration,
+        options={
+            CONF_PATTERN: "",
+            CONF_ONLY_EXTENSIONS: "",
+            CONF_EXCEPT_EXTENSIONS: "",
+        },
+    )
+    await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            TEXT_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: "text.test_cleanup_only_extensions", ATTR_VALUE: "."},
+            blocking=True,
+        )
+
+    error_msg = str(exc_info.value).lower()
+    assert (
+        "extension_too_short" in error_msg
+        or "too short" in error_msg
+        or "short" in error_msg
+    ), "Should reject extension with no characters after dot"
+
+
+async def test_text_entity_availability(hass: HomeAssistant, init_integration):
+    """Test text entity availability based on coordinator."""
+    coordinator = init_integration.runtime_data
+
+    state = hass.states.get("text.test_cleanup_pattern")
+    assert state.state != "unavailable", "Should be available when coordinator is ready"
+
+    coordinator.async_set_updated_data(None)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("text.test_cleanup_pattern")
+    assert (
+        state.state != "unavailable"
+    ), "Text entity should remain available even with no coordinator data"
+
+
+async def test_only_extensions_rejects_except_extensions_explicit(
+    hass: HomeAssistant, init_integration
+):
+    """Test only_extensions rejects except_extensions when already set."""
+    hass.config_entries.async_update_entry(
+        init_integration,
+        options={
+            CONF_PATTERN: "",
+            CONF_ONLY_EXTENSIONS: TEST_VALID_EXTENSIONS_ONLY,
+            CONF_EXCEPT_EXTENSIONS: "",
+        },
+    )
+    await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            TEXT_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: "text.test_cleanup_except_extensions",
+                ATTR_VALUE: TEST_VALID_EXTENSIONS_EXCEPT,
+            },
+            blocking=True,
+        )
+
+    error_msg = str(exc_info.value).lower()
+    assert (
+        "cannot_use_both_only_and_except" in error_msg
+        or "both" in error_msg
+        or "exclusive" in error_msg
+    ), "Should reject except_extensions when only_extensions is set"
+
+
+async def test_except_extensions_rejects_pattern_explicit(
+    hass: HomeAssistant, init_integration
+):
+    """Test except_extensions rejects pattern when pattern is set."""
+    hass.config_entries.async_update_entry(
+        init_integration,
+        options={
+            CONF_PATTERN: TEST_VALID_PATTERN,
+            CONF_ONLY_EXTENSIONS: "",
+            CONF_EXCEPT_EXTENSIONS: "",
+        },
+    )
+    await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            TEXT_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: "text.test_cleanup_except_extensions",
+                ATTR_VALUE: TEST_VALID_EXTENSIONS_EXCEPT,
+            },
+            blocking=True,
+        )
+
+    error_msg = str(exc_info.value).lower()
+    assert (
+        "cannot_combine_pattern_and_extensions" in error_msg
+        or "cannot" in error_msg
+        or "pattern" in error_msg
+    ), "Should reject except_extensions when pattern is set"
+
+
+async def test_except_extensions_rejects_only_extensions_explicit(
+    hass: HomeAssistant, init_integration
+):
+    """Test except_extensions rejects only_extensions when already set."""
+    hass.config_entries.async_update_entry(
+        init_integration,
+        options={
+            CONF_PATTERN: "",
+            CONF_ONLY_EXTENSIONS: TEST_VALID_EXTENSIONS_ONLY,
+            CONF_EXCEPT_EXTENSIONS: "",
+        },
+    )
+    await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            TEXT_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: "text.test_cleanup_except_extensions",
+                ATTR_VALUE: TEST_VALID_EXTENSIONS_EXCEPT,
+            },
+            blocking=True,
+        )
+
+    error_msg = str(exc_info.value).lower()
+    assert (
+        "cannot_use_both_only_and_except" in error_msg
+        or "both" in error_msg
+        or "exclusive" in error_msg
+    ), "Should reject except_extensions when only_extensions is set"
+
+
+async def test_only_extensions_rejects_when_except_extensions_set(
+    hass: HomeAssistant, init_integration
+):
+    """Test only_extensions rejects when except_extensions is already set."""
+    hass.config_entries.async_update_entry(
+        init_integration,
+        options={
+            CONF_PATTERN: "",
+            CONF_ONLY_EXTENSIONS: "",
+            CONF_EXCEPT_EXTENSIONS: TEST_VALID_EXTENSIONS_EXCEPT,
+        },
+    )
+    await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            TEXT_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: "text.test_cleanup_only_extensions",
+                ATTR_VALUE: TEST_VALID_EXTENSIONS_ONLY,
+            },
+            blocking=True,
+        )
+
+    error_msg = str(exc_info.value).lower()
+    assert (
+        "cannot_use_both_only_and_except" in error_msg
+        or "both" in error_msg
+        or "exclusive" in error_msg
+    ), "Should reject only_extensions when except_extensions is set"
+
+
+async def test_except_extensions_allows_empty_value(
+    hass: HomeAssistant, init_integration
+):
+    """Test except_extensions allows empty value to clear filter."""
+    hass.config_entries.async_update_entry(
+        init_integration,
+        options={
+            CONF_PATTERN: TEST_VALID_PATTERN,
+            CONF_ONLY_EXTENSIONS: "",
+            CONF_EXCEPT_EXTENSIONS: TEST_VALID_EXTENSIONS_EXCEPT,
+        },
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        TEXT_DOMAIN,
+        SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: "text.test_cleanup_except_extensions",
+            ATTR_VALUE: "",
+        },
+        blocking=True,
+    )
+
+    state = hass.states.get("text.test_cleanup_except_extensions")
+    assert state is not None, "Text entity should exist"
+    assert state.state == "", "Empty value should be allowed to clear filter"

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,0 +1,362 @@
+"""Test retention_cleaner time entities."""
+
+from datetime import time as dt_time
+from unittest.mock import patch
+
+from homeassistant.components.time import (
+    ATTR_TIME,
+    DOMAIN as TIME_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.const import ATTR_ENTITY_ID, EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+import pytest
+
+from custom_components.retention_cleaner.const import CONF_RUN_AT, DOMAIN
+
+
+async def test_time_entity_setup(hass: HomeAssistant, init_integration):
+    """Test time entity is created during platform setup."""
+    state = hass.states.get("time.test_cleanup_run_at")
+    assert state is not None, "run_at time entity should exist"
+
+
+async def test_time_entity_initial_value(hass: HomeAssistant, init_integration):
+    """Test initial time matches coordinator config (HH:MM format)."""
+    coordinator = init_integration.runtime_data
+
+    state = hass.states.get("time.test_cleanup_run_at")
+    assert state is not None, "run_at time entity should exist"
+
+    coordinator_time = coordinator.run_at
+    state_time = dt_time.fromisoformat(state.state)
+
+    assert (
+        state_time.hour == coordinator_time.hour
+        and state_time.minute == coordinator_time.minute
+    ), "Initial time should match coordinator config"
+
+
+async def test_time_entity_set_value(hass: HomeAssistant, init_integration):
+    """Test setting time updates the entity state."""
+    await hass.services.async_call(
+        TIME_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: "time.test_cleanup_run_at", ATTR_TIME: "14:30:00"},
+        blocking=True,
+    )
+
+    state = hass.states.get("time.test_cleanup_run_at")
+    assert state is not None, "Time entity should still exist"
+
+    state_time = dt_time.fromisoformat(state.state)
+    assert (
+        state_time.hour == 14 and state_time.minute == 30
+    ), "State should be updated to new time"
+
+
+async def test_time_entity_set_value_updates_config(
+    hass: HomeAssistant, init_integration
+):
+    """Test config is persisted via async_update_config_value."""
+    coordinator = init_integration.runtime_data
+
+    with (
+        patch.object(coordinator, "async_update_config_value") as mock_update_config,
+        patch.object(hass.config_entries, "async_update_entry"),
+    ):
+        await hass.services.async_call(
+            TIME_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: "time.test_cleanup_run_at", ATTR_TIME: "04:45:00"},
+            blocking=True,
+        )
+
+        mock_update_config.assert_called_once_with(CONF_RUN_AT, "04:45")
+
+
+async def test_time_entity_triggers_scheduler_update(
+    hass: HomeAssistant, init_integration
+):
+    """Test setting time calls async_setup_daily_schedule()."""
+    coordinator = init_integration.runtime_data
+
+    with (
+        patch.object(coordinator, "async_setup_daily_schedule") as mock_setup_schedule,
+        patch.object(hass.config_entries, "async_update_entry"),
+    ):
+        await hass.services.async_call(
+            TIME_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: "time.test_cleanup_run_at", ATTR_TIME: "05:15:00"},
+            blocking=True,
+        )
+
+        await hass.async_block_till_done()
+
+        mock_setup_schedule.assert_called_once()
+
+
+async def test_time_entity_validates_format(hass: HomeAssistant, init_integration):
+    """Test HH:MM format validation."""
+    state = hass.states.get("time.test_cleanup_run_at")
+    assert state is not None, "Time entity should exist"
+
+    state_time = dt_time.fromisoformat(state.state)
+    assert isinstance(state_time, dt_time), "Should have valid time object"
+    assert state_time.second == 0, "Seconds should be zero"
+
+
+async def test_time_entity_attributes(hass: HomeAssistant, init_integration):
+    """Test time entity attributes and configuration."""
+    registry = er.async_get(hass)
+
+    entry = registry.async_get("time.test_cleanup_run_at")
+    assert entry is not None, "Time entity should exist in registry"
+    assert (
+        entry.unique_id == f"{init_integration.entry_id}_run_at"
+    ), "Should have correct unique_id format"
+    assert (
+        entry.entity_category == EntityCategory.CONFIG
+    ), "Should have CONFIG entity category"
+
+    state = hass.states.get("time.test_cleanup_run_at")
+    assert state is not None, "Time entity state should exist"
+
+
+async def test_time_entity_device_info(hass: HomeAssistant, init_integration):
+    """Test that time entity is linked to the correct device."""
+    registry = er.async_get(hass)
+
+    entry = registry.async_get("time.test_cleanup_run_at")
+    assert entry is not None, "Time entity should exist"
+    assert entry.device_id is not None, "Should be linked to device"
+
+    try:
+        device_registry = hass.helpers.device_registry.async_get()
+    except TypeError:
+        device_registry = hass.helpers.device_registry.async_get(hass)
+
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, init_integration.entry_id)}
+    )
+    assert device is not None, "Device should exist"
+    assert device.name == "Test Cleanup", "Device should have correct name"
+    assert device.model == "Folder retention rule", "Device should have correct model"
+    assert (
+        device.manufacturer == "Retention Cleaner"
+    ), "Device should have correct manufacturer"
+    assert (
+        DOMAIN,
+        init_integration.entry_id,
+    ) in device.identifiers, "Device should have correct identifiers"
+
+
+async def test_time_entity_unique_id_stable(hass: HomeAssistant, init_integration):
+    """Test that time entity unique ID remains stable."""
+    registry = er.async_get(hass)
+    entry_id = init_integration.entry_id
+
+    entity_id = registry.async_get_entity_id(TIME_DOMAIN, DOMAIN, f"{entry_id}_run_at")
+    assert entity_id is not None, "Time entity should be found by unique_id"
+    assert entity_id == "time.test_cleanup_run_at", "Should have correct entity_id"
+
+
+async def test_time_entity_updates_from_coordinator(
+    hass: HomeAssistant, init_integration
+):
+    """Test that time entity reflects coordinator config changes."""
+    coordinator = init_integration.runtime_data
+
+    await coordinator.async_update_config_value(CONF_RUN_AT, "06:45")
+    await hass.async_block_till_done()
+
+    state = hass.states.get("time.test_cleanup_run_at")
+    assert state is not None, "Time entity should still exist"
+
+    state_time = dt_time.fromisoformat(state.state)
+    assert (
+        state_time.hour == 6 and state_time.minute == 45
+    ), "State should reflect updated coordinator config"
+
+
+@pytest.mark.parametrize(
+    ("time_value", "expected_hour", "expected_minute"),
+    [
+        ("00:00:00", 0, 0),
+        ("23:59:00", 23, 59),
+        ("12:00:00", 12, 0),
+        ("03:15:00", 3, 15),
+    ],
+)
+async def test_time_entity_boundary_values(
+    hass: HomeAssistant, init_integration, time_value, expected_hour, expected_minute
+):
+    """Test setting boundary time values (00:00 to 23:59)."""
+    await hass.services.async_call(
+        TIME_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: "time.test_cleanup_run_at", ATTR_TIME: time_value},
+        blocking=True,
+    )
+
+    state = hass.states.get("time.test_cleanup_run_at")
+    assert state is not None, "Time entity should exist"
+
+    state_time = dt_time.fromisoformat(state.state)
+    assert (
+        state_time.hour == expected_hour and state_time.minute == expected_minute
+    ), f"Should accept time value {time_value}"
+
+
+async def test_time_entity_multiple_updates(hass: HomeAssistant, init_integration):
+    """Test multiple time updates work correctly."""
+    coordinator = init_integration.runtime_data
+
+    await hass.services.async_call(
+        TIME_DOMAIN,
+        SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: "time.test_cleanup_run_at",
+            ATTR_TIME: "10:30:00",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("time.test_cleanup_run_at")
+    state_time = dt_time.fromisoformat(state.state)
+    assert state_time.hour == 10 and state_time.minute == 30, "Should update to 10:30"
+
+    coordinator_time = coordinator.run_at
+    assert (
+        coordinator_time.hour == 10 and coordinator_time.minute == 30
+    ), "Coordinator should have 10:30"
+
+    await hass.services.async_call(
+        TIME_DOMAIN,
+        SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: "time.test_cleanup_run_at",
+            ATTR_TIME: "15:45:00",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("time.test_cleanup_run_at")
+    state_time = dt_time.fromisoformat(state.state)
+    assert state_time.hour == 15 and state_time.minute == 45, "Should update to 15:45"
+
+    coordinator_time = coordinator.run_at
+    assert (
+        coordinator_time.hour == 15 and coordinator_time.minute == 45
+    ), "Coordinator should have 15:45"
+
+
+async def test_time_entity_availability(hass: HomeAssistant, init_integration):
+    """Test time entity availability based on coordinator."""
+    coordinator = init_integration.runtime_data
+
+    state = hass.states.get("time.test_cleanup_run_at")
+    assert state.state != "unavailable", "Should be available when coordinator is ready"
+
+    coordinator.async_set_updated_data(None)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("time.test_cleanup_run_at")
+    assert (
+        state.state != "unavailable"
+    ), "Time entity should remain available even with no coordinator data"
+
+
+async def test_time_entity_default_value(hass: HomeAssistant):
+    """Test default time value when not specified in config."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    entry_default = MockConfigEntry(
+        domain="retention_cleaner",
+        title="Test Default Time",
+        data={
+            "base_path": "/media/test",
+            "pattern": "*.jpg",
+            "retention_days": 7,
+            "dry_run": True,
+            "max_deletes": 100,
+        },
+        entry_id="test_default_time_entry",
+    )
+    entry_default.add_to_hass(hass)
+
+    with (
+        patch("pathlib.Path.exists", return_value=True),
+        patch("pathlib.Path.is_dir", return_value=True),
+        patch("pathlib.Path.glob", return_value=[]),
+    ):
+        assert await hass.config_entries.async_setup(entry_default.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("time.test_default_time_run_at")
+    assert state is not None, "Time entity should exist"
+
+    state_time = dt_time.fromisoformat(state.state)
+    assert state_time.hour == 3 and state_time.minute == 15, "Should default to 03:15"
+
+
+async def test_time_entity_formats_hh_mm_correctly(
+    hass: HomeAssistant, init_integration
+):
+    """Test that time is stored as HH:MM string in config."""
+    coordinator = init_integration.runtime_data
+
+    with (
+        patch.object(coordinator, "async_update_config_value") as mock_update_config,
+        patch.object(hass.config_entries, "async_update_entry"),
+    ):
+        await hass.services.async_call(
+            TIME_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: "time.test_cleanup_run_at", ATTR_TIME: "07:09:00"},
+            blocking=True,
+        )
+
+        mock_update_config.assert_called_once_with(CONF_RUN_AT, "07:09")
+
+
+async def test_time_entity_strips_seconds(hass: HomeAssistant, init_integration):
+    """Test that seconds are stripped from time value."""
+    await hass.services.async_call(
+        TIME_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: "time.test_cleanup_run_at", ATTR_TIME: "08:30:59"},
+        blocking=True,
+    )
+
+    state = hass.states.get("time.test_cleanup_run_at")
+    assert state is not None, "Time entity should exist"
+
+    state_time = dt_time.fromisoformat(state.state)
+    assert state_time.second == 0, "Seconds should be stripped to 0"
+
+
+async def test_time_entity_scheduler_reschedule_on_change(
+    hass: HomeAssistant, init_integration
+):
+    """Test that changing time triggers scheduler update."""
+    coordinator = init_integration.runtime_data
+
+    with (
+        patch.object(coordinator, "async_setup_daily_schedule") as mock_schedule,
+        patch.object(hass.config_entries, "async_update_entry"),
+    ):
+        await hass.services.async_call(
+            TIME_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: "time.test_cleanup_run_at", ATTR_TIME: "09:00:00"},
+            blocking=True,
+        )
+
+        await hass.async_block_till_done()
+
+        mock_schedule.assert_called_once()


### PR DESCRIPTION
## Summary
  Adds runtime configuration entities for editing all settings directly in the Home Assistant UI without restarting.

  ## What's New

  ### Configuration Entities
  - **Number**: `retention_days`, `max_deletes`, `keep_minimum_files`, `max_files_in_folder`
  - **Switch**: `dry_run`, `remove_empty_folders` (migrated from Select entity)
  - **Text**: `pattern`, `only_extensions`, `except_extensions` (with validation)
  - **Time**: `run_at` (daily cleanup schedule)
  - **Sensor**: `base_path` (read-only diagnostic)

  Changes trigger immediate scan and take effect without restart.

  ## Fixed
  - Number entities now return integers, preventing decimal separators in localized UIs (e.g., "1,0" → "1")

  ## Breaking Changes
  ⚠️ **Sensor attributes removed**: `base_path`, `pattern`, `retention_days` moved to dedicated config entities. Update
  automations/templates to use new entity IDs.